### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/167/179/421167179.geojson
+++ b/data/421/167/179/421167179.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"MZ",
     "wof:created":1459008722,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"17dda35a55a6b07a979ece5dba93b0e8",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421167179,
-    "wof:lastmodified":1566646781,
+    "wof:lastmodified":1582349847,
     "wof:name":"Angoche",
     "wof:parent_id":1091696277,
     "wof:placetype":"locality",

--- a/data/421/167/893/421167893.geojson
+++ b/data/421/167/893/421167893.geojson
@@ -574,6 +574,9 @@
     ],
     "wof:country":"MZ",
     "wof:created":1459008747,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a37daa35e7977ed94df3faf0340159d",
     "wof:hierarchy":[
         {
@@ -585,7 +588,7 @@
         }
     ],
     "wof:id":421167893,
-    "wof:lastmodified":1566646781,
+    "wof:lastmodified":1582349847,
     "wof:name":"Maputo",
     "wof:parent_id":1091697125,
     "wof:placetype":"locality",

--- a/data/421/178/563/421178563.geojson
+++ b/data/421/178/563/421178563.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"MZ",
     "wof:created":1459009186,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"82cd00cb2ca7f2d18a937acc6f1d8d32",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         }
     ],
     "wof:id":421178563,
-    "wof:lastmodified":1566646786,
+    "wof:lastmodified":1582349848,
     "wof:name":"Moatize",
     "wof:parent_id":1091699971,
     "wof:placetype":"locality",

--- a/data/421/190/949/421190949.geojson
+++ b/data/421/190/949/421190949.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"MZ",
     "wof:created":1459009674,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0db9e998949908b2acadd2e0f871fed6",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":421190949,
-    "wof:lastmodified":1566646784,
+    "wof:lastmodified":1582349847,
     "wof:name":"Quissico",
     "wof:parent_id":1091701681,
     "wof:placetype":"locality",

--- a/data/421/190/951/421190951.geojson
+++ b/data/421/190/951/421190951.geojson
@@ -233,6 +233,9 @@
     },
     "wof:country":"MZ",
     "wof:created":1459009674,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4cfd2c106daf655ec37c243bf133c69b",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         }
     ],
     "wof:id":421190951,
-    "wof:lastmodified":1561758261,
+    "wof:lastmodified":1582349847,
     "wof:name":"Mapai",
     "wof:parent_id":1091696621,
     "wof:placetype":"locality",

--- a/data/421/195/459/421195459.geojson
+++ b/data/421/195/459/421195459.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"MZ",
     "wof:created":1459009849,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"7ec5ecabad6f866dde3b1b52e0e022d2",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":421195459,
-    "wof:lastmodified":1561758260,
+    "wof:lastmodified":1582349847,
     "wof:name":"Vilanculos",
     "wof:parent_id":1091701605,
     "wof:placetype":"locality",

--- a/data/856/327/29/85632729.geojson
+++ b/data/856/327/29/85632729.geojson
@@ -973,6 +973,11 @@
     },
     "wof:country":"MZ",
     "wof:country_alpha3":"MOZ",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"42d12c8f1047a5b169eef74461b633fb",
     "wof:hierarchy":[
         {
@@ -987,7 +992,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645267,
+    "wof:lastmodified":1582349820,
     "wof:name":"Mozambique",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/748/11/85674811.geojson
+++ b/data/856/748/11/85674811.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Tete Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d00bf3e7187a5793a2eb0e31515c47cb",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645255,
+    "wof:lastmodified":1582349812,
     "wof:name":"Tete",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/15/85674815.geojson
+++ b/data/856/748/15/85674815.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Manica Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66e143704ae43d8596d53152e51eae8c",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645265,
+    "wof:lastmodified":1582349818,
     "wof:name":"Manica",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/17/85674817.geojson
+++ b/data/856/748/17/85674817.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Cabo Delgado Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c8d00c0c04887923bac74fe0214fee5",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645258,
+    "wof:lastmodified":1582349814,
     "wof:name":"Cabo Delgado",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/21/85674821.geojson
+++ b/data/856/748/21/85674821.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Niassa Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75b40a0fd04d99ec118cc1a63e8ba6a9",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645260,
+    "wof:lastmodified":1582349815,
     "wof:name":"Niassa",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/27/85674827.geojson
+++ b/data/856/748/27/85674827.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Nampula Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd3fa56fba66006fedfac81a03fed5d5",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645253,
+    "wof:lastmodified":1582349811,
     "wof:name":"Nampula",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/31/85674831.geojson
+++ b/data/856/748/31/85674831.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Gaza Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42e6520b0359360219fd8451a0503cf0",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645261,
+    "wof:lastmodified":1582349816,
     "wof:name":"Gaza",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/35/85674835.geojson
+++ b/data/856/748/35/85674835.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Sofala Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2306b32d9068fd38ce97f84e0037bf0",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645250,
+    "wof:lastmodified":1582349810,
     "wof:name":"Sofala",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/39/85674839.geojson
+++ b/data/856/748/39/85674839.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Zambezia Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"580235eb61878114489be95fee59a095",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645263,
+    "wof:lastmodified":1582349817,
     "wof:name":"Zambezia",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/45/85674845.geojson
+++ b/data/856/748/45/85674845.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Inhambane Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8117a3617025154542ba6421c4e2fea2",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645256,
+    "wof:lastmodified":1582349813,
     "wof:name":"Inhambane",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/49/85674849.geojson
+++ b/data/856/748/49/85674849.geojson
@@ -189,6 +189,9 @@
         "wk:page":"Maputo Province"
     },
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01c490cd56dd3136fb010a1a0465da6b",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645266,
+    "wof:lastmodified":1582349819,
     "wof:name":"Maputo",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/53/85674853.geojson
+++ b/data/856/748/53/85674853.geojson
@@ -202,6 +202,9 @@
         421167893
     ],
     "wof:country":"MZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41df8a34d36ad5d82dfbfa1997824bde",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566645262,
+    "wof:lastmodified":1582349817,
     "wof:name":"Maputo",
     "wof:parent_id":85632729,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.