### PR TITLE
Name updates

### DIFF
--- a/data/114/190/713/5/1141907135.geojson
+++ b/data/114/190/713/5/1141907135.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"32.8799979235,-18.9696056937,32.8799979235,-18.9696056937",
+    "geom:bbox":"32.879998,-18.969606,32.879998,-18.969606",
     "geom:latitude":-18.969606,
     "geom:longitude":32.879998,
     "iso:country":"MZ",
@@ -130,7 +130,7 @@
         "\u0645\u0627\u0646\u06cc\u06a9\u0627 \u060c \u0645\u0648\u0632\u0627\u0645\u0628\u06cc\u0642\u0648\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0645\u0627\u0646\u06cc\u06a9\u0627 "
+        "\u0645\u0627\u0646\u06cc\u06a9\u0627"
     ],
     "name:vie_x_preferred":[
         "Manica"
@@ -237,8 +237,8 @@
     "wof:belongsto":[
         102191573,
         85632729,
-        85674815,
-        1091699043
+        1091699043,
+        85674815
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -246,7 +246,7 @@
     },
     "wof:country":"MZ",
     "wof:created":1499130686,
-    "wof:geomhash":"31525dbdf575a49475b2aa0d757aa622",
+    "wof:geomhash":"75a434fc017bb5f9853adc3c992fc26e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -257,7 +257,7 @@
         }
     ],
     "wof:id":1141907135,
-    "wof:lastmodified":1566647615,
+    "wof:lastmodified":1587163114,
     "wof:name":"Manica",
     "wof:parent_id":1091699043,
     "wof:placetype":"locality",
@@ -267,10 +267,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    32.87999792352167,
-    -18.96960569374437,
-    32.87999792352167,
-    -18.96960569374437
+    32.879998,
+    -18.969606,
+    32.879998,
+    -18.969606
 ],
-  "geometry": {"coordinates":[32.87999792352167,-18.96960569374437],"type":"Point"}
+  "geometry": {"coordinates":[32.879998,-18.969606],"type":"Point"}
 }

--- a/data/421/166/899/421166899.geojson
+++ b/data/421/166/899/421166899.geojson
@@ -111,7 +111,7 @@
         "\u0db8\u0dd0\u0d9a\u0dca\u0dc3\u0dd2\u0d9a\u0dca\u0dc3\u0dda"
     ],
     "name:sin_x_variant":[
-        "\u0db8\u0dd0\u0d9a\u0dca\u0dc3\u0dd2\u0d9a\u0dca\u0dc3\u0dda "
+        "\u0db8\u0dd0\u0d9a\u0dca\u0dc3\u0dd2\u0d9a\u0dca\u0dc3\u0dda"
     ],
     "name:spa_x_preferred":[
         "Maxixe"
@@ -138,7 +138,7 @@
         "\u0645\u0627\u0632\u06cc\u0632\u06cc \u060c \u0645\u0648\u0632\u0627\u0645\u0628\u06cc\u0642\u0648\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0645\u0627\u0632\u06cc\u0632\u06cc "
+        "\u0645\u0627\u0632\u06cc\u0632\u06cc"
     ],
     "name:vie_x_preferred":[
         "Maxixe"
@@ -264,8 +264,8 @@
     "wof:belongsto":[
         102191573,
         85632729,
-        85674845,
-        1091699509
+        1091699509,
+        85674845
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -288,7 +288,7 @@
         }
     ],
     "wof:id":421166899,
-    "wof:lastmodified":1566646780,
+    "wof:lastmodified":1587163137,
     "wof:name":"Maxixe",
     "wof:parent_id":1091699509,
     "wof:placetype":"locality",

--- a/data/856/327/29/85632729.geojson
+++ b/data/856/327/29/85632729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":66.98453,
-    "geom:area_square_m":789054339303.417358,
+    "geom:area_square_m":789054337550.243896,
     "geom:bbox":"30.21555,-26.868161,40.848751,-10.477195",
     "geom:latitude":-17.260097,
     "geom:longitude":35.55384,
@@ -55,6 +55,9 @@
     "name:arg_x_preferred":[
         "Mozambique"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0648\u0632\u0627\u0645\u0628\u064a\u0642"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u0648\u0632\u0627\u0645\u0628\u064a\u0642"
     ],
@@ -81,6 +84,9 @@
     ],
     "name:bam_x_variant":[
         "Mozanbiki"
+    ],
+    "name:ban_x_preferred":[
+        "Mozambik"
     ],
     "name:bcl_x_preferred":[
         "Mosambik"
@@ -166,6 +172,9 @@
     "name:dan_x_variant":[
         "Mo\u00e7ambique"
     ],
+    "name:deu_ch_x_preferred":[
+        "Mosambik"
+    ],
     "name:deu_x_preferred":[
         "Mosambik"
     ],
@@ -186,6 +195,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03bf\u03b6\u03b1\u03bc\u03b2\u03af\u03ba\u03b7"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Mozambique"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Mozambique"
     ],
     "name:eng_x_preferred":[
         "Mozambique"
@@ -249,6 +264,9 @@
     ],
     "name:gag_x_preferred":[
         "Mozambik"
+    ],
+    "name:gcr_x_preferred":[
+        "Mozanbik"
     ],
     "name:gla_x_preferred":[
         "M\u00f2saimbic"
@@ -545,6 +563,9 @@
     "name:nov_x_preferred":[
         "Mozambik"
     ],
+    "name:nqo_x_preferred":[
+        "\u07e1\u07cf\u07d6\u07ed\u07ca\u07f2\u07d3\u07cc\u07de\u07cc\u07ec"
+    ],
     "name:nso_x_preferred":[
         "Mozambique"
     ],
@@ -595,6 +616,9 @@
     ],
     "name:pol_x_preferred":[
         "Mozambik"
+    ],
+    "name:por_br_x_preferred":[
+        "Mo\u00e7ambique"
     ],
     "name:por_x_colloquial":[
         "Mocambique"
@@ -659,6 +683,9 @@
     "name:sna_x_preferred":[
         "Mozambique"
     ],
+    "name:snd_x_preferred":[
+        "\u0645\u0648\u0632\u0645\u0628\u064a\u0642"
+    ],
     "name:som_x_preferred":[
         "Musanbiig"
     ],
@@ -679,6 +706,12 @@
     ],
     "name:srd_x_preferred":[
         "Mozambico"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041c\u043e\u0437\u0430\u043c\u0431\u0438\u043a"
+    ],
+    "name:srp_el_x_preferred":[
+        "Mozambik"
     ],
     "name:srp_x_preferred":[
         "\u041c\u043e\u0437\u0430\u043c\u0431\u0438\u043a"
@@ -706,6 +739,9 @@
     ],
     "name:szl_x_preferred":[
         "Mozambik"
+    ],
+    "name:szy_x_preferred":[
+        "Mozambique"
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bca\u0b9a\u0bbe\u0bae\u0bcd\u0baa\u0bbf\u0b95\u0bcd"
@@ -822,11 +858,20 @@
     "name:yue_x_preferred":[
         "\u83ab\u4e09\u9f3b\u7d66"
     ],
+    "name:zea_x_preferred":[
+        "Mozambique"
+    ],
     "name:zha_x_preferred":[
         "Mozambique"
     ],
+    "name:zho_hk_x_preferred":[
+        "\u83ab\u6851\u6bd4\u514b"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Mo\u00e7ambique"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u83ab\u4e09\u6bd4\u514b"
     ],
     "name:zho_x_preferred":[
         "\u83ab\u6851\u6bd4\u514b"
@@ -993,7 +1038,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1583797395,
+    "wof:lastmodified":1587428952,
     "wof:name":"Mozambique",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.