### PR TITLE
Update megacity records

### DIFF
--- a/data/421/167/893/421167893.geojson
+++ b/data/421/167/893/421167893.geojson
@@ -567,6 +567,7 @@
         "gn:id":1040652,
         "gp:id":1550363,
         "loc:id":"n78060679",
+        "ne:id":1159150683,
         "qs_pg:id":273869,
         "wd:id":"Q3889",
         "wk:page":"Maputo"
@@ -590,7 +591,8 @@
         }
     ],
     "wof:id":421167893,
-    "wof:lastmodified":1607390876,
+    "wof:lastmodified":1608688176,
+    "wof:megacity":1,
     "wof:name":"Maputo",
     "wof:parent_id":1091697125,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary