### PR TITLE
mz concordances, placetype local, and more

### DIFF
--- a/data/109/169/621/3/1091696213.geojson
+++ b/data/109/169/621/3/1091696213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.534402,
-    "geom:area_square_m":6362963201.556172,
+    "geom:area_square_m":6362963555.629704,
     "geom:bbox":"37.206654,-16.300774,38.031498,-15.102282",
     "geom:latitude":-15.649321,
     "geom:longitude":37.663844,
@@ -107,9 +107,10 @@
         "hasc:id":"MZ.ZA.AM",
         "wd:id":"Q4736799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879571,
-    "wof:geomhash":"05afec27ff90500a9b7cacba9d97f9c6",
+    "wof:geomhash":"481d3c25b7a93e851707ce4738304831",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091696213,
-    "wof:lastmodified":1690848237,
+    "wof:lastmodified":1695886392,
     "wof:name":"Alto Molocue",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/624/1/1091696241.geojson
+++ b/data/109/169/624/1/1091696241.geojson
@@ -109,6 +109,7 @@
         "hasc:id":"MZ.CD.AN",
         "wd:id":"Q2640799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879573,
     "wof:geomhash":"06f70fd7decb467266cf167f67e29a7d",
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091696241,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886401,
     "wof:name":"Ancuabe",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/627/7/1091696277.geojson
+++ b/data/109/169/627/7/1091696277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254977,
-    "geom:area_square_m":3029278848.052745,
+    "geom:area_square_m":3029278962.906673,
     "geom:bbox":"39.404793,-16.47353,40.143768,-15.713491",
     "geom:latitude":-16.093356,
     "geom:longitude":39.804676,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879575,
-    "wof:geomhash":"c34c99e3e3ae15f48d7c6272173d716e",
+    "wof:geomhash":"1a198a33ee64d6377fa8ee64889fb5fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1091696277,
-    "wof:lastmodified":1636501808,
+    "wof:lastmodified":1695886797,
     "wof:name":"Angoche",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/632/3/1091696323.geojson
+++ b/data/109/169/632/3/1091696323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273586,
-    "geom:area_square_m":3272595775.714094,
+    "geom:area_square_m":3272595599.47924,
     "geom:bbox":"33.734371,-15.150656,34.55064,-14.384274",
     "geom:latitude":-14.673889,
     "geom:longitude":34.163274,
@@ -101,9 +101,10 @@
         "hasc:id":"MZ.TE.AN",
         "wd:id":"Q2849724"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879576,
-    "wof:geomhash":"7cd8060969373c8b5306df2fd7579496",
+    "wof:geomhash":"1c9520ec3d6b4b6b8ec8ea22516968b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091696323,
-    "wof:lastmodified":1690848239,
+    "wof:lastmodified":1695886396,
     "wof:name":"Angonia",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/634/9/1091696349.geojson
+++ b/data/109/169/634/9/1091696349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.458943,
-    "geom:area_square_m":5518889247.099515,
+    "geom:area_square_m":5518889738.922115,
     "geom:bbox":"38.037182,-14.160389,38.826332,-12.916069",
     "geom:latitude":-13.463893,
     "geom:longitude":38.407073,
@@ -118,9 +118,10 @@
         "hasc:id":"MZ.CD.BA",
         "wd:id":"Q508480"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879578,
-    "wof:geomhash":"ce98b9ac28d14eeb246416f96574cfe7",
+    "wof:geomhash":"91d013fc86fec02470f500fd1d295bfa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091696349,
-    "wof:lastmodified":1690848238,
+    "wof:lastmodified":1695886394,
     "wof:name":"Balama",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/635/9/1091696359.geojson
+++ b/data/109/169/635/9/1091696359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.492665,
-    "geom:area_square_m":5793841683.743613,
+    "geom:area_square_m":5793841986.127589,
     "geom:bbox":"32.937153,-18.668396,33.555805,-17.238588",
     "geom:latitude":-17.993775,
     "geom:longitude":33.225028,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879579,
-    "wof:geomhash":"f868c18f2c235c42a71f2edc27cf6e8b",
+    "wof:geomhash":"0885a3193c394eb6dee8230641be2104",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091696359,
-    "wof:lastmodified":1627522444,
+    "wof:lastmodified":1695886044,
     "wof:name":"Barue",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/636/1/1091696361.geojson
+++ b/data/109/169/636/1/1091696361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195157,
-    "geom:area_square_m":2186590870.091589,
+    "geom:area_square_m":2186591086.133057,
     "geom:bbox":"32.903408,-25.380955,33.458328,-24.76243",
     "geom:latitude":-25.025808,
     "geom:longitude":33.175327,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.GA.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879581,
-    "wof:geomhash":"602f7fad5a46b8dea227f98c6081b428",
+    "wof:geomhash":"865de44a29976e513af2a5a458feea58",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091696361,
-    "wof:lastmodified":1627522444,
+    "wof:lastmodified":1695886044,
     "wof:name":"Bilene",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/636/3/1091696363.geojson
+++ b/data/109/169/636/3/1091696363.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.MP.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879583,
     "wof:geomhash":"e3c25b80a7baa2e38a74b35850310124",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091696363,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886045,
     "wof:name":"Boane",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/639/5/1091696395.geojson
+++ b/data/109/169/639/5/1091696395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.624313,
-    "geom:area_square_m":7252318306.759483,
+    "geom:area_square_m":7252318273.501072,
     "geom:bbox":"33.89299,-20.565617,34.788086,-19.580845",
     "geom:latitude":-20.039043,
     "geom:longitude":34.372117,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879584,
-    "wof:geomhash":"9f17d32f513d298dd90262d178c6958a",
+    "wof:geomhash":"dd600efd13396324b34d5df73e8fda5c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091696395,
-    "wof:lastmodified":1627522444,
+    "wof:lastmodified":1695886045,
     "wof:name":"Buzi",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/646/7/1091696467.geojson
+++ b/data/109/169/646/7/1091696467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.747074,
-    "geom:area_square_m":8878621519.337749,
+    "geom:area_square_m":8878623049.521282,
     "geom:bbox":"31.92086,-16.605007,33.11272,-15.551954",
     "geom:latitude":-16.025539,
     "geom:longitude":32.5056,
@@ -104,9 +104,10 @@
         "hasc:id":"MZ.TE.CB",
         "wd:id":"Q4891530"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879586,
-    "wof:geomhash":"3a937db1260e35060333f4d7c02fbee5",
+    "wof:geomhash":"7d610d26d8d83b3a311158170220af65",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091696467,
-    "wof:lastmodified":1690848245,
+    "wof:lastmodified":1695886402,
     "wof:name":"Cahora Bassa",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/649/3/1091696493.geojson
+++ b/data/109/169/649/3/1091696493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.305392,
-    "geom:area_square_m":3595792621.591712,
+    "geom:area_square_m":3595792643.786996,
     "geom:bbox":"34.728054,-18.236633,35.462067,-17.361851",
     "geom:latitude":-17.782501,
     "geom:longitude":35.008312,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879588,
-    "wof:geomhash":"cec9bb0b7b31bd8b1b730fde450fade9",
+    "wof:geomhash":"3bf91436eff48754d53c75c9621b07e7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091696493,
-    "wof:lastmodified":1627522445,
+    "wof:lastmodified":1695886048,
     "wof:name":"Caia",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/653/7/1091696537.geojson
+++ b/data/109/169/653/7/1091696537.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879589,
     "wof:geomhash":"18a3a985c3a2628ab6be599179e4640e",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091696537,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886048,
     "wof:name":"Changara",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/655/7/1091696557.geojson
+++ b/data/109/169/655/7/1091696557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.337899,
-    "geom:area_square_m":3991186405.997898,
+    "geom:area_square_m":3991185652.620618,
     "geom:bbox":"34.174805,-17.653019,35.002174,-16.797598",
     "geom:latitude":-17.20599,
     "geom:longitude":34.630099,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879591,
-    "wof:geomhash":"17366239b08bd04be54ac0c21fb614bc",
+    "wof:geomhash":"e27146412a5d02f5160f5727b4de8a39",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091696557,
-    "wof:lastmodified":1627522445,
+    "wof:lastmodified":1695886049,
     "wof:name":"Chemba",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/655/9/1091696559.geojson
+++ b/data/109/169/655/9/1091696559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.60787,
-    "geom:area_square_m":7126783323.958878,
+    "geom:area_square_m":7126783582.865696,
     "geom:bbox":"34.635342,-19.117228,35.910938,-17.855661",
     "geom:latitude":-18.528422,
     "geom:longitude":35.222444,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.SO.CR",
         "wd:id":"Q5091967"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879593,
-    "wof:geomhash":"a79186a3a6b133b7c6522417c6600bc8",
+    "wof:geomhash":"96298bc6dc42c277d62d6a900bc03065",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091696559,
-    "wof:lastmodified":1690848247,
+    "wof:lastmodified":1695886404,
     "wof:name":"Cheringoma",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/656/1/1091696561.geojson
+++ b/data/109/169/656/1/1091696561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.604951,
-    "geom:area_square_m":7012506331.568147,
+    "geom:area_square_m":7012508239.81942,
     "geom:bbox":"33.384979,-20.999989,34.417732,-19.596432",
     "geom:latitude":-20.36884,
     "geom:longitude":33.883556,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879594,
-    "wof:geomhash":"837c29b1cbd8c3318dc5b585c2fa5804",
+    "wof:geomhash":"283f8f326283958dbf63d14064ac4754",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091696561,
-    "wof:lastmodified":1627522446,
+    "wof:lastmodified":1695886049,
     "wof:name":"Chibabava",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/658/3/1091696583.geojson
+++ b/data/109/169/658/3/1091696583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.498554,
-    "geom:area_square_m":5618453209.059502,
+    "geom:area_square_m":5618453558.457169,
     "geom:bbox":"33.261929,-24.8741,33.956024,-23.655912",
     "geom:latitude":-24.300603,
     "geom:longitude":33.609953,
@@ -109,9 +109,10 @@
         "hasc:id":"MZ.GA.CB",
         "wd:id":"Q602291"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879596,
-    "wof:geomhash":"6cd6c8c2dcde0ab8fc7c988a0609da13",
+    "wof:geomhash":"15ce1e0cf3b3437de511498f50262e56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091696583,
-    "wof:lastmodified":1690848239,
+    "wof:lastmodified":1695886395,
     "wof:name":"Chibuto",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/662/1/1091696621.geojson
+++ b/data/109/169/662/1/1091696621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.588716,
-    "geom:area_square_m":18120378452.917488,
+    "geom:area_square_m":18120375732.116886,
     "geom:bbox":"31.306313,-23.584587,32.902485,-21.872313",
     "geom:latitude":-22.716503,
     "geom:longitude":32.032354,
@@ -109,9 +109,10 @@
         "hasc:id":"MZ.GA.CC",
         "wd:id":"Q2577748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879598,
-    "wof:geomhash":"5cc29d6ac799442493b073fe12630856",
+    "wof:geomhash":"d3484f060c0b55faef48d258d034af28",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091696621,
-    "wof:lastmodified":1690848248,
+    "wof:lastmodified":1695886405,
     "wof:name":"Chicualacuala",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/665/9/1091696659.geojson
+++ b/data/109/169/665/9/1091696659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.788973,
-    "geom:area_square_m":9440019615.92403,
+    "geom:area_square_m":9440020736.956255,
     "geom:bbox":"32.169937,-15.422463,33.319336,-13.998883",
     "geom:latitude":-14.614503,
     "geom:longitude":32.828576,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.CF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879599,
-    "wof:geomhash":"bf4373fb1e6a506d57abe6545c465597",
+    "wof:geomhash":"483930ca2610dbb3dbc72431fa46a3c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091696659,
-    "wof:lastmodified":1627522446,
+    "wof:lastmodified":1695886050,
     "wof:name":"Chifunde",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/670/9/1091696709.geojson
+++ b/data/109/169/670/9/1091696709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.323904,
-    "geom:area_square_m":15078121079.269136,
+    "geom:area_square_m":15078122117.395226,
     "geom:bbox":"32.586021,-23.95216,33.950901,-21.960445",
     "geom:latitude":-22.911699,
     "geom:longitude":33.24966,
@@ -106,9 +106,10 @@
         "hasc:id":"MZ.GA.CG",
         "wd:id":"Q2749205"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879601,
-    "wof:geomhash":"f31c6c70e54a079dcb08ec7ae594c9e1",
+    "wof:geomhash":"65e2f7758a139b4696d6eecb537fe863",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091696709,
-    "wof:lastmodified":1690848245,
+    "wof:lastmodified":1695886403,
     "wof:name":"Chigubo",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/672/9/1091696729.geojson
+++ b/data/109/169/672/9/1091696729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.362245,
-    "geom:area_square_m":4250330392.188139,
+    "geom:area_square_m":4250330392.18709,
     "geom:bbox":"35.8201065063,-18.9023704529,36.8303833008,-18.0307350159",
     "geom:latitude":-18.394915,
     "geom:longitude":36.322677,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879602,
-    "wof:geomhash":"8a2f0a867dad1432fcf7f3e3967374a4",
+    "wof:geomhash":"a25445c323693f10cfdf3b6835fc220d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091696729,
-    "wof:lastmodified":1566646616,
+    "wof:lastmodified":1695886392,
     "wof:name":"Chinde",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/677/1/1091696771.geojson
+++ b/data/109/169/677/1/1091696771.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"MZ.CD.AN",
         "wd:id":"Q2640799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879605,
     "wof:geomhash":"96716327059d6e339d2f935df178deb1",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091696771,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886403,
     "wof:name":"Chiure",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/682/5/1091696825.geojson
+++ b/data/109/169/682/5/1091696825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.599996,
-    "geom:area_square_m":7150213221.203427,
+    "geom:area_square_m":7150212551.693635,
     "geom:bbox":"32.916565,-15.936675,34.042194,-15.080769",
     "geom:latitude":-15.470653,
     "geom:longitude":33.454608,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879606,
-    "wof:geomhash":"de8e1b11e42cb781ce806861b34ec3f0",
+    "wof:geomhash":"8e4c40be53bfba104a1c928080205bae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091696825,
-    "wof:lastmodified":1627522446,
+    "wof:lastmodified":1695886050,
     "wof:name":"Chiuta",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/684/9/1091696849.geojson
+++ b/data/109/169/684/9/1091696849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217848,
-    "geom:area_square_m":2449968543.90198,
+    "geom:area_square_m":2449969769.266758,
     "geom:bbox":"32.560032,-24.864445,33.522972,-24.108652",
     "geom:latitude":-24.56186,
     "geom:longitude":32.955684,
@@ -107,9 +107,10 @@
         "hasc:id":"MZ.GA.CK",
         "wd:id":"Q2048783"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879608,
-    "wof:geomhash":"fe9803c9e61e9a2853577d981ffbf486",
+    "wof:geomhash":"2ec9b5d80f015cac50851c4cd2c5cf5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091696849,
-    "wof:lastmodified":1690848246,
+    "wof:lastmodified":1695886404,
     "wof:name":"Chokwe",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/689/9/1091696899.geojson
+++ b/data/109/169/689/9/1091696899.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879609,
     "wof:geomhash":"bb7db41447013c373b40414ff902b981",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091696899,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886047,
     "wof:name":"Cidade da Beira",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/695/3/1091696953.geojson
+++ b/data/109/169/695/3/1091696953.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.MP.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879611,
     "wof:geomhash":"54148506ab8f3455c200e8984496daeb",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091696953,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886061,
     "wof:name":"Cidade da Matola",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/698/7/1091696987.geojson
+++ b/data/109/169/698/7/1091696987.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879612,
     "wof:geomhash":"635e35c6ee6ba2643cdc4f9f944a8658",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091696987,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886051,
     "wof:name":"Cidade de Chimoio",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/702/9/1091697029.geojson
+++ b/data/109/169/702/9/1091697029.geojson
@@ -92,6 +92,7 @@
         "hasc:id":"MZ.IN.JA",
         "wd:id":"Q5946674"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879614,
     "wof:geomhash":"37e31e266bf0062ac2c4a3f484dabaaf",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091697029,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886397,
     "wof:name":"Cidade de Inhambane",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/707/7/1091697077.geojson
+++ b/data/109/169/707/7/1091697077.geojson
@@ -86,6 +86,7 @@
         "hasc:id":"MZ.NS.LI",
         "wd:id":"Q2090184"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879615,
     "wof:geomhash":"80b02f6d4fd984da7d43ce71b9e76c53",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091697077,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886392,
     "wof:name":"Cidade de Lichinga",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/712/5/1091697125.geojson
+++ b/data/109/169/712/5/1091697125.geojson
@@ -80,7 +80,7 @@
         }
     ],
     "wof:id":1091697125,
-    "wof:lastmodified":1694639720,
+    "wof:lastmodified":1695886059,
     "wof:name":"Cidade de Maputo",
     "wof:parent_id":85674853,
     "wof:placetype":"county",

--- a/data/109/169/715/1/1091697151.geojson
+++ b/data/109/169/715/1/1091697151.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879618,
     "wof:geomhash":"da7fb1aa94085a90f795f5d387d7353f",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091697151,
-    "wof:lastmodified":1695886068,
+    "wof:lastmodified":1696023153,
     "wof:name":"Cidade de Nampula",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/715/1/1091697151.geojson
+++ b/data/109/169/715/1/1091697151.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1091697151,
-    "wof:lastmodified":1694492706,
+    "wof:lastmodified":1695886068,
     "wof:name":"Cidade de Nampula",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/719/7/1091697197.geojson
+++ b/data/109/169/719/7/1091697197.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.CD.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879620,
     "wof:geomhash":"e17e8efc1a5f883cf376cd622bc7b03d",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091697197,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886070,
     "wof:name":"Cidade de Pemba",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/725/9/1091697259.geojson
+++ b/data/109/169/725/9/1091697259.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879622,
     "wof:geomhash":"3c192d7c04e24df0aa4168bed756055e",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091697259,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886070,
     "wof:name":"Cidade de Quelimane",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/728/7/1091697287.geojson
+++ b/data/109/169/728/7/1091697287.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879623,
     "wof:geomhash":"02da210146b69e50dc9d3dadc6da99a2",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091697287,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886073,
     "wof:name":"Cidade de Tete",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/733/3/1091697333.geojson
+++ b/data/109/169/733/3/1091697333.geojson
@@ -89,6 +89,7 @@
         "hasc:id":"MZ.GA.XX",
         "wd:id":"Q2215180"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879624,
     "wof:geomhash":"68853c3cf31bb94a9bea4cc6f2976330",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091697333,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886397,
     "wof:name":"Cidade de Xai-Xai",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/737/5/1091697375.geojson
+++ b/data/109/169/737/5/1091697375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.448548,
-    "geom:area_square_m":5363618128.05296,
+    "geom:area_square_m":5363618813.592759,
     "geom:bbox":"36.141407,-15.271412,37.085793,-14.223697",
     "geom:latitude":-14.747815,
     "geom:longitude":36.544848,
@@ -150,9 +150,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879626,
-    "wof:geomhash":"08c481e333c1545a65491ba5f6ec447a",
+    "wof:geomhash":"b236beb35fc88dc6f3f0d0ff2fd92ed1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1091697375,
-    "wof:lastmodified":1636501808,
+    "wof:lastmodified":1695886797,
     "wof:name":"Cuamba",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/741/1/1091697411.geojson
+++ b/data/109/169/741/1/1091697411.geojson
@@ -126,6 +126,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879628,
     "wof:geomhash":"746ca0e5eae389f35f2423f33d000ba1",
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1091697411,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886797,
     "wof:name":"Dondo",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/745/5/1091697455.geojson
+++ b/data/109/169/745/5/1091697455.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879629,
     "wof:geomhash":"e0898da47331e1eb3d0e20db3b98eaea",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091697455,
-    "wof:lastmodified":1695886051,
+    "wof:lastmodified":1696023153,
     "wof:name":"Erati",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/745/5/1091697455.geojson
+++ b/data/109/169/745/5/1091697455.geojson
@@ -80,7 +80,7 @@
         }
     ],
     "wof:id":1091697455,
-    "wof:lastmodified":1694492706,
+    "wof:lastmodified":1695886051,
     "wof:name":"Erati",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/750/5/1091697505.geojson
+++ b/data/109/169/750/5/1091697505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.200278,
-    "geom:area_square_m":13655950377.365837,
+    "geom:area_square_m":13655950096.634323,
     "geom:bbox":"33.646088,-23.714006,34.962341,-22.154814",
     "geom:latitude":-23.055279,
     "geom:longitude":34.306372,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.IN.FU",
         "wd:id":"Q5509190"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879631,
-    "wof:geomhash":"d94b38d9fabb2273cea42af6ed767749",
+    "wof:geomhash":"7cf7e920523392c676b8f862b998a1fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091697505,
-    "wof:lastmodified":1690848242,
+    "wof:lastmodified":1695886399,
     "wof:name":"Funhalouro",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/754/5/1091697545.geojson
+++ b/data/109/169/754/5/1091697545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.757694,
-    "geom:area_square_m":9009215721.632637,
+    "geom:area_square_m":9009215721.63232,
     "geom:bbox":"37.8078689575,-16.5259990692,38.9428405762,-15.2332248688",
     "geom:latitude":-15.927919,
     "geom:longitude":38.306652,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879632,
-    "wof:geomhash":"9896069be0e153ccb710e8000c839e74",
+    "wof:geomhash":"1328226d827e90395d271fbbaf13d76b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091697545,
-    "wof:lastmodified":1566646614,
+    "wof:lastmodified":1695886391,
     "wof:name":"Gile",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/758/5/1091697585.geojson
+++ b/data/109/169/758/5/1091697585.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879634,
     "wof:geomhash":"5e516cf45085b4b542b94ce4fc109361",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091697585,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886051,
     "wof:name":"Cidade de Chimoio",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/763/1/1091697631.geojson
+++ b/data/109/169/763/1/1091697631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.580282,
-    "geom:area_square_m":6799938905.380785,
+    "geom:area_square_m":6799939244.010341,
     "geom:bbox":"33.723778,-19.164087,34.708294,-18.122688",
     "geom:latitude":-18.613609,
     "geom:longitude":34.217183,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879636,
-    "wof:geomhash":"eaa20d13fbc6c9f40727d4ca6543c7f3",
+    "wof:geomhash":"28f7fe9418573adb9870cbd793d38da5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091697631,
-    "wof:lastmodified":1627522447,
+    "wof:lastmodified":1695886052,
     "wof:name":"Gorongosa",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/767/3/1091697673.geojson
+++ b/data/109/169/767/3/1091697673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.345339,
-    "geom:area_square_m":3977977172.96087,
+    "geom:area_square_m":3977977794.304905,
     "geom:bbox":"34.023907,-21.678148,35.131622,-20.954969",
     "geom:latitude":-21.31853,
     "geom:longitude":34.676044,
@@ -100,9 +100,10 @@
         "hasc:id":"MZ.IN.GO",
         "wd:id":"Q5589969"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879638,
-    "wof:geomhash":"3e033cae26eceedb334dc233dd863bc7",
+    "wof:geomhash":"eef98e794ca07f0586ae2e52bf28eb4b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091697673,
-    "wof:lastmodified":1690848242,
+    "wof:lastmodified":1695886398,
     "wof:name":"Govuro",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/772/1/1091697721.geojson
+++ b/data/109/169/772/1/1091697721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372332,
-    "geom:area_square_m":4200416719.034444,
+    "geom:area_square_m":4200417491.059275,
     "geom:bbox":"32.74147,-24.640905,33.431149,-23.64257",
     "geom:latitude":-24.167199,
     "geom:longitude":33.121402,
@@ -104,9 +104,10 @@
         "hasc:id":"MZ.GA.GU",
         "wd:id":"Q2680874"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879639,
-    "wof:geomhash":"ed836bfd29475044dc82b0bce1d36282",
+    "wof:geomhash":"c791229f408f2ab66e0ef15eeb17d59e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091697721,
-    "wof:lastmodified":1690848249,
+    "wof:lastmodified":1695886406,
     "wof:name":"Guija",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/777/1/1091697771.geojson
+++ b/data/109/169/777/1/1091697771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.587963,
-    "geom:area_square_m":6953553133.667427,
+    "geom:area_square_m":6953553006.959112,
     "geom:bbox":"33.08979,-17.519253,33.956795,-16.387352",
     "geom:latitude":-16.972208,
     "geom:longitude":33.538423,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879641,
-    "wof:geomhash":"5b16a211aed2d46cf6827ba961d3c949",
+    "wof:geomhash":"697c08f8cc4d88555eaf23d3fd8a549a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091697771,
-    "wof:lastmodified":1627522447,
+    "wof:lastmodified":1695886053,
     "wof:name":"Guro",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/780/1/1091697801.geojson
+++ b/data/109/169/780/1/1091697801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.475014,
-    "geom:area_square_m":5664092527.450849,
+    "geom:area_square_m":5664092565.544981,
     "geom:bbox":"36.461876,-15.923437,37.387905,-14.999998",
     "geom:latitude":-15.349169,
     "geom:longitude":36.947449,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879642,
-    "wof:geomhash":"c64960f36ff4f692f0cc9d40d1c1d2f2",
+    "wof:geomhash":"816c7c4f8ac192902f1919101c519ac1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091697801,
-    "wof:lastmodified":1627522447,
+    "wof:lastmodified":1695886053,
     "wof:name":"Gurue",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/785/3/1091697853.geojson
+++ b/data/109/169/785/3/1091697853.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.IN.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879644,
     "wof:geomhash":"b86edc8ba52b1276c805a63bcc22529a",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091697853,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886053,
     "wof:name":"Homoine",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/789/7/1091697897.geojson
+++ b/data/109/169/789/7/1091697897.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.CD.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879645,
     "wof:geomhash":"da12c40e2c7bb9217c3fa54e58d096b9",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091697897,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886054,
     "wof:name":"Ibo",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/794/3/1091697943.geojson
+++ b/data/109/169/794/3/1091697943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.476157,
-    "geom:area_square_m":5654506342.745601,
+    "geom:area_square_m":5654505764.454905,
     "geom:bbox":"37.074589,-16.669338,37.993515,-15.596621",
     "geom:latitude":-16.180379,
     "geom:longitude":37.466093,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.IL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879647,
-    "wof:geomhash":"2f79fee41100d2a9a0d79e90a1f3de3b",
+    "wof:geomhash":"deafb776011f9cd529b77ae6be709a30",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091697943,
-    "wof:lastmodified":1636501809,
+    "wof:lastmodified":1695886798,
     "wof:name":"Ile",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/797/7/1091697977.geojson
+++ b/data/109/169/797/7/1091697977.geojson
@@ -89,6 +89,7 @@
         "hasc:id":"MZ.NM.MS",
         "wd:id":"Q6436077"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879649,
     "wof:geomhash":"75938207eb28801126bae5bb1ee96ae2",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091697977,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886390,
     "wof:name":"Ilha de Mocambique",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/801/9/1091698019.geojson
+++ b/data/109/169/801/9/1091698019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.244543,
-    "geom:area_square_m":2753730788.704075,
+    "geom:area_square_m":2753730821.283473,
     "geom:bbox":"34.131367,-24.610371,35.387585,-24.203768",
     "geom:latitude":-24.400397,
     "geom:longitude":34.771523,
@@ -106,9 +106,10 @@
         "hasc:id":"MZ.IN.IR",
         "wd:id":"Q6033707"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879650,
-    "wof:geomhash":"59e0feaa8b7cc837c9b691a841078434",
+    "wof:geomhash":"76e2908e6a4798030e8e6e41c45cefb2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091698019,
-    "wof:lastmodified":1690848248,
+    "wof:lastmodified":1695886405,
     "wof:name":"Inharrime",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/806/3/1091698063.geojson
+++ b/data/109/169/806/3/1091698063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.41426,
-    "geom:area_square_m":4757705044.587308,
+    "geom:area_square_m":4757706559.550896,
     "geom:bbox":"34.375523,-22.091051,35.497879,-21.342833",
     "geom:latitude":-21.750166,
     "geom:longitude":34.859112,
@@ -106,9 +106,10 @@
         "hasc:id":"MZ.IN.IS",
         "wd:id":"Q11683219"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879651,
-    "wof:geomhash":"c1cb2df802152898117822629c5e9dfa",
+    "wof:geomhash":"e29ae605e469f42ba19526eb58ef7ea0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091698063,
-    "wof:lastmodified":1690848248,
+    "wof:lastmodified":1695886405,
     "wof:name":"Inhassoro",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/809/7/1091698097.geojson
+++ b/data/109/169/809/7/1091698097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064384,
-    "geom:area_square_m":756914498.088869,
+    "geom:area_square_m":756914486.712551,
     "geom:bbox":"36.646835,-18.246223,36.966694,-17.882446",
     "geom:latitude":-18.056246,
     "geom:longitude":36.803399,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879653,
-    "wof:geomhash":"09f544f9c325e840a459df39cca6de5d",
+    "wof:geomhash":"7c29251a10803336d4eb5a4faddacf31",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698097,
-    "wof:lastmodified":1627522448,
+    "wof:lastmodified":1695886054,
     "wof:name":"Inhassunge",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/814/7/1091698147.geojson
+++ b/data/109/169/814/7/1091698147.geojson
@@ -91,6 +91,7 @@
         "hasc:id":"MZ.IN.JA",
         "wd:id":"Q5946674"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879655,
     "wof:geomhash":"fbbbc35e07f1b6979ccae6c29796b1a5",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1091698147,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886402,
     "wof:name":"Jangamo",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/819/3/1091698193.geojson
+++ b/data/109/169/819/3/1091698193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.124429,
-    "geom:area_square_m":13579559470.514929,
+    "geom:area_square_m":13579558935.207487,
     "geom:bbox":"34.350483,-13.482909,35.417564,-11.569075",
     "geom:latitude":-12.388053,
     "geom:longitude":34.821634,
@@ -100,9 +100,10 @@
         "hasc:id":"MZ.NS.LA",
         "wd:id":"Q15241257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879656,
-    "wof:geomhash":"66c8bd92e9b40b453701b0c0da9e07e9",
+    "wof:geomhash":"18ca9901fd05111523b2dc77376a2aab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091698193,
-    "wof:lastmodified":1690848237,
+    "wof:lastmodified":1695886393,
     "wof:name":"Lago",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/823/3/1091698233.geojson
+++ b/data/109/169/823/3/1091698233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379843,
-    "geom:area_square_m":4548518573.792961,
+    "geom:area_square_m":4548518637.465977,
     "geom:bbox":"37.672852,-14.819051,38.70031,-14.11857",
     "geom:latitude":-14.43637,
     "geom:longitude":38.126726,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.NM.LA",
         "wd:id":"Q6436032"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879658,
-    "wof:geomhash":"82e96ac91c125ef959cc8d4f129ec9fa",
+    "wof:geomhash":"5bc8dca47879febecb753fbc62346bf1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091698233,
-    "wof:lastmodified":1690848243,
+    "wof:lastmodified":1695886400,
     "wof:name":"Lalaua",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/828/3/1091698283.geojson
+++ b/data/109/169/828/3/1091698283.geojson
@@ -86,6 +86,7 @@
         "hasc:id":"MZ.NS.LI",
         "wd:id":"Q2090184"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879659,
     "wof:geomhash":"72661715f3898550f3fbaa9206c3bb8c",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091698283,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886393,
     "wof:name":"Cidade de Lichinga",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/832/7/1091698327.geojson
+++ b/data/109/169/832/7/1091698327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.518142,
-    "geom:area_square_m":6149193524.423338,
+    "geom:area_square_m":6149193267.921844,
     "geom:bbox":"36.146255,-16.83115,37.157303,-15.825414",
     "geom:latitude":-16.305629,
     "geom:longitude":36.653583,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879661,
-    "wof:geomhash":"ffda3c425d7bd21c159dd985ba418107",
+    "wof:geomhash":"41a540427dff61e216443cadb31b6eda",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698327,
-    "wof:lastmodified":1627522448,
+    "wof:lastmodified":1695886054,
     "wof:name":"Lugela",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/836/5/1091698365.geojson
+++ b/data/109/169/836/5/1091698365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.789225,
-    "geom:area_square_m":8950805457.144936,
+    "geom:area_square_m":8950803611.683668,
     "geom:bbox":"32.238121,-24.192669,33.24876,-22.966085",
     "geom:latitude":-23.478867,
     "geom:longitude":32.737941,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.GA.MB",
         "wd:id":"Q6322311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879662,
-    "wof:geomhash":"190d14113f1fe1fba78b7fe24e01f8df",
+    "wof:geomhash":"afee7b570b304dad0bc8dd9d1821c797",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091698365,
-    "wof:lastmodified":1690848247,
+    "wof:lastmodified":1695886404,
     "wof:name":"Mabalane",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/840/5/1091698405.geojson
+++ b/data/109/169/840/5/1091698405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.341198,
-    "geom:area_square_m":15375922393.836195,
+    "geom:area_square_m":15375922804.389633,
     "geom:bbox":"33.161545,-22.905035,34.634563,-21.300356",
     "geom:latitude":-22.002786,
     "geom:longitude":33.80151,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.IN.MB",
         "wd:id":"Q6318356"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879664,
-    "wof:geomhash":"c796d462e9a1f01d21ca21a130ac4c21",
+    "wof:geomhash":"f0140d7bc5defbe0dd45a96508151a44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091698405,
-    "wof:lastmodified":1690848244,
+    "wof:lastmodified":1695886402,
     "wof:name":"Mabote",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/845/5/1091698455.geojson
+++ b/data/109/169/845/5/1091698455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.604204,
-    "geom:area_square_m":7223107780.964802,
+    "geom:area_square_m":7223107738.915892,
     "geom:bbox":"33.021336,-15.281737,34.07832,-14.14623",
     "geom:latitude":-14.801614,
     "geom:longitude":33.534856,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879666,
-    "wof:geomhash":"698340fc31fae3e9e7fb3ad01baafcf6",
+    "wof:geomhash":"1468d8414c15ffa797175b426124d1b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698455,
-    "wof:lastmodified":1627522448,
+    "wof:lastmodified":1695886055,
     "wof:name":"Macanga",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/848/7/1091698487.geojson
+++ b/data/109/169/848/7/1091698487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.496291,
-    "geom:area_square_m":5732484152.926121,
+    "geom:area_square_m":5732484498.147757,
     "geom:bbox":"33.98035,-21.316055,35.130775,-20.511593",
     "geom:latitude":-20.91189,
     "geom:longitude":34.522236,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879667,
-    "wof:geomhash":"8331fd545a817d5c935ba9ad426f420c",
+    "wof:geomhash":"a801283e310e4261a1875b40a004fc6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698487,
-    "wof:lastmodified":1627522448,
+    "wof:lastmodified":1695886055,
     "wof:name":"Machanga",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/853/5/1091698535.geojson
+++ b/data/109/169/853/5/1091698535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.155385,
-    "geom:area_square_m":13333703911.917038,
+    "geom:area_square_m":13333701984.577288,
     "geom:bbox":"32.363888,-21.582447,34.112133,-20.286787",
     "geom:latitude":-21.042521,
     "geom:longitude":33.27127,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.MZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879669,
-    "wof:geomhash":"5de7d7cd52c205a427b0de900b3effaa",
+    "wof:geomhash":"69e0b0e523ecda4587a0b9580fb8364b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698535,
-    "wof:lastmodified":1627522448,
+    "wof:lastmodified":1695886056,
     "wof:name":"Machaze",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/858/3/1091698583.geojson
+++ b/data/109/169/858/3/1091698583.geojson
@@ -100,6 +100,7 @@
         "hasc:id":"MZ.CD.MA",
         "wd:id":"Q2444619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879671,
     "wof:geomhash":"37742620bebe55cc9348bc34b67feb06",
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091698583,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886396,
     "wof:name":"Macomia",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/862/5/1091698625.geojson
+++ b/data/109/169/862/5/1091698625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.815494,
-    "geom:area_square_m":9594927755.054659,
+    "geom:area_square_m":9594927609.448729,
     "geom:bbox":"33.358383,-18.731567,34.292175,-17.327341",
     "geom:latitude":-17.910235,
     "geom:longitude":33.789389,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879673,
-    "wof:geomhash":"dc006dc421b819fb38e1a39e0df78017",
+    "wof:geomhash":"ed32f041c61890ec931c5948c5d40e92",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698625,
-    "wof:lastmodified":1627522449,
+    "wof:lastmodified":1695886057,
     "wof:name":"Macossa",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/867/1/1091698671.geojson
+++ b/data/109/169/867/1/1091698671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.648154,
-    "geom:area_square_m":7659862227.151027,
+    "geom:area_square_m":7659862368.453783,
     "geom:bbox":"37.062122,-17.669781,38.117184,-16.531883",
     "geom:latitude":-17.10781,
     "geom:longitude":37.62383,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879674,
-    "wof:geomhash":"202e569c49df32ef135cfdf0b4f49674",
+    "wof:geomhash":"c1e97b908bcae8fb59f8eab955463235",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698671,
-    "wof:lastmodified":1627522449,
+    "wof:lastmodified":1695886057,
     "wof:name":"Maganja da Costa",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/872/3/1091698723.geojson
+++ b/data/109/169/872/3/1091698723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.721821,
-    "geom:area_square_m":8583880804.211375,
+    "geom:area_square_m":8583879898.065556,
     "geom:bbox":"30.419125,-16.417183,32.158611,-15.61932",
     "geom:latitude":-15.901697,
     "geom:longitude":31.36315,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879676,
-    "wof:geomhash":"20ba2e9ecadfc427ad09b7f6760be29e",
+    "wof:geomhash":"17906b3edb7daff3d0b1d604d2f83b93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698723,
-    "wof:lastmodified":1627522449,
+    "wof:lastmodified":1695886058,
     "wof:name":"Magoe",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/876/3/1091698763.geojson
+++ b/data/109/169/876/3/1091698763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.621461,
-    "geom:area_square_m":6981259177.626272,
+    "geom:area_square_m":6981258535.811881,
     "geom:bbox":"31.952467,-25.313406,32.95507,-24.203913",
     "geom:latitude":-24.701493,
     "geom:longitude":32.438971,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.MP.MG",
         "wd:id":"Q6484234"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879678,
-    "wof:geomhash":"8c34f7e31c79bc953739aaac090f5e2d",
+    "wof:geomhash":"0232f9adbf6b1582f430d2b62ca9e9be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091698763,
-    "wof:lastmodified":1690848244,
+    "wof:lastmodified":1695886400,
     "wof:name":"Magude",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/882/3/1091698823.geojson
+++ b/data/109/169/882/3/1091698823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.942593,
-    "geom:area_square_m":11341621555.452311,
+    "geom:area_square_m":11341621511.76878,
     "geom:bbox":"35.615604,-13.986546,37.005009,-12.668669",
     "geom:latitude":-13.320555,
     "geom:longitude":36.37365,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879680,
-    "wof:geomhash":"b674f0a67c311b35254648b674dd9e1d",
+    "wof:geomhash":"6d28a172bc093efdd4074e92c5ca2afe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091698823,
-    "wof:lastmodified":1627522449,
+    "wof:lastmodified":1695886059,
     "wof:name":"Majune",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/886/3/1091698863.geojson
+++ b/data/109/169/886/3/1091698863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.508192,
-    "geom:area_square_m":6075438448.11875,
+    "geom:area_square_m":6075438208.933597,
     "geom:bbox":"36.695835,-15.194759,37.947205,-14.273657",
     "geom:latitude":-14.798173,
     "geom:longitude":37.390486,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.NM.MA",
         "wd:id":"Q6436099"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879681,
-    "wof:geomhash":"b651923f4757355e2e90db419f9f7fe2",
+    "wof:geomhash":"148e217a887c820f9239e5a2f26633e7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091698863,
-    "wof:lastmodified":1690848238,
+    "wof:lastmodified":1695886394,
     "wof:name":"Malema",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/892/3/1091698923.geojson
+++ b/data/109/169/892/3/1091698923.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879683,
     "wof:geomhash":"4a137fd835b4e03c05311f88c2a73c20",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091698923,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886059,
     "wof:name":"Mandimba",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/896/7/1091698967.geojson
+++ b/data/109/169/896/7/1091698967.geojson
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":1091698967,
-    "wof:lastmodified":1694492406,
+    "wof:lastmodified":1695886405,
     "wof:name":"Mandlakaze",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/896/7/1091698967.geojson
+++ b/data/109/169/896/7/1091698967.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"MZ.GA.MJ",
         "wd:id":"Q6489660"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879685,
     "wof:geomhash":"77c7a1c6ae3be59e34b77a212a31c4e4",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1091698967,
-    "wof:lastmodified":1695886405,
+    "wof:lastmodified":1696023152,
     "wof:name":"Mandlakaze",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/901/5/1091699015.geojson
+++ b/data/109/169/901/5/1091699015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212074,
-    "geom:area_square_m":2370612216.937774,
+    "geom:area_square_m":2370611001.571483,
     "geom:bbox":"32.51413,-25.596207,33.137318,-24.980211",
     "geom:latitude":-25.309744,
     "geom:longitude":32.825775,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MP.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879687,
-    "wof:geomhash":"0e19f7cca339d5e7516a70f5bcc3d609",
+    "wof:geomhash":"3ef5244b2ed8dd4a3973f8f3f3cc0797",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091699015,
-    "wof:lastmodified":1627522450,
+    "wof:lastmodified":1695886060,
     "wof:name":"Manhica",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/904/3/1091699043.geojson
+++ b/data/109/169/904/3/1091699043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.375994,
-    "geom:area_square_m":4400333505.721556,
+    "geom:area_square_m":4400333882.258441,
     "geom:bbox":"32.698315,-19.259073,33.453648,-18.344238",
     "geom:latitude":-18.832294,
     "geom:longitude":33.108714,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879688,
-    "wof:geomhash":"cbd3517a194f88c49c9cefdbc3896ff8",
+    "wof:geomhash":"b012593453b32b3e7b622b1527a4784e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091699043,
-    "wof:lastmodified":1636501810,
+    "wof:lastmodified":1695886799,
     "wof:name":"Manica",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/169/909/3/1091699093.geojson
+++ b/data/109/169/909/3/1091699093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.4044,
-    "geom:area_square_m":16766289196.946594,
+    "geom:area_square_m":16766290156.908197,
     "geom:bbox":"31.3493,-15.696738,32.988884,-14.34801",
     "geom:latitude":-15.094053,
     "geom:longitude":32.065961,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879690,
-    "wof:geomhash":"13e370ee873b660d5a12cac4c17cd315",
+    "wof:geomhash":"7bb956828e0c3c83f4ea7758468ae98d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091699093,
-    "wof:lastmodified":1627522450,
+    "wof:lastmodified":1695886060,
     "wof:name":"Maravia",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/169/914/1/1091699141.geojson
+++ b/data/109/169/914/1/1091699141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.524269,
-    "geom:area_square_m":6170267696.378282,
+    "geom:area_square_m":6170267107.957332,
     "geom:bbox":"34.139309,-18.416771,34.86713,-17.209871",
     "geom:latitude":-17.857706,
     "geom:longitude":34.484821,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879691,
-    "wof:geomhash":"5c7d221a4023398a62ca28fd47c7c469",
+    "wof:geomhash":"4790e929deb14fd614a2487b82740684",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091699141,
-    "wof:lastmodified":1627522450,
+    "wof:lastmodified":1695886061,
     "wof:name":"Maringue",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/917/5/1091699175.geojson
+++ b/data/109/169/917/5/1091699175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062671,
-    "geom:area_square_m":698533535.171539,
+    "geom:area_square_m":698533328.636069,
     "geom:bbox":"32.551342,-25.873001,32.975655,-25.475464",
     "geom:latitude":-25.657218,
     "geom:longitude":32.71213,
@@ -100,9 +100,10 @@
         "hasc:id":"MZ.MP.MR",
         "wd:id":"Q6484180"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879693,
-    "wof:geomhash":"851df25acdc0c3ee5b36baf20030a9e5",
+    "wof:geomhash":"7e352f9a98a189cf5560e6dd20ce547a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091699175,
-    "wof:lastmodified":1690848249,
+    "wof:lastmodified":1695886407,
     "wof:name":"Marracuene",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/921/5/1091699215.geojson
+++ b/data/109/169/921/5/1091699215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.491986,
-    "geom:area_square_m":5771563289.675756,
+    "geom:area_square_m":5771563160.272097,
     "geom:bbox":"35.291698,-18.960571,36.189751,-17.846783",
     "geom:latitude":-18.425263,
     "geom:longitude":35.740979,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879694,
-    "wof:geomhash":"dd05a25f04a6d386d26b77d41b66ae26",
+    "wof:geomhash":"72eb78863add5d1e43420b8404a6f549",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091699215,
-    "wof:lastmodified":1627522450,
+    "wof:lastmodified":1695886061,
     "wof:name":"Marromeu",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/169/925/7/1091699257.geojson
+++ b/data/109/169/925/7/1091699257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.45462,
-    "geom:area_square_m":17523160280.788284,
+    "geom:area_square_m":17523159927.536865,
     "geom:bbox":"36.699909,-13.898727,38.23431,-12.177667",
     "geom:latitude":-13.030274,
     "geom:longitude":37.519621,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879696,
-    "wof:geomhash":"163961f865aec1f8a73febb74a701844",
+    "wof:geomhash":"aab83f4caaffcb6f619ba266366bf1a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091699257,
-    "wof:lastmodified":1636501809,
+    "wof:lastmodified":1695886798,
     "wof:name":"Marrupa",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/928/1/1091699281.geojson
+++ b/data/109/169/928/1/1091699281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.658709,
-    "geom:area_square_m":7565296176.686888,
+    "geom:area_square_m":7565296792.169347,
     "geom:bbox":"31.87652,-22.176861,33.296371,-21.309015",
     "geom:latitude":-21.748023,
     "geom:longitude":32.593378,
@@ -136,9 +136,10 @@
         "hasc:id":"MZ.GA.MS",
         "wd:id":"Q6489681"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879698,
-    "wof:geomhash":"6fc83bc7c8ccfdd9f60a896903e0eb5d",
+    "wof:geomhash":"af72c23fdcb7ec1b59fd25cdb28aa345",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091699281,
-    "wof:lastmodified":1690848250,
+    "wof:lastmodified":1695886799,
     "wof:name":"Massangena",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/931/3/1091699313.geojson
+++ b/data/109/169/931/3/1091699313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.651728,
-    "geom:area_square_m":7427013872.101822,
+    "geom:area_square_m":7427012929.516918,
     "geom:bbox":"34.351501,-23.485704,35.604565,-22.204952",
     "geom:latitude":-22.836913,
     "geom:longitude":35.021388,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.IN.MS",
         "wd:id":"Q5668856"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879699,
-    "wof:geomhash":"d80cba401c03244c0c5f74432ed1b30d",
+    "wof:geomhash":"96c6407212a15a573f3b8d5132669506",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091699313,
-    "wof:lastmodified":1690848236,
+    "wof:lastmodified":1695886391,
     "wof:name":"Massinga",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/934/7/1091699347.geojson
+++ b/data/109/169/934/7/1091699347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.503896,
-    "geom:area_square_m":5697832320.549824,
+    "geom:area_square_m":5697832621.750145,
     "geom:bbox":"31.549906,-24.347273,32.639824,-23.224934",
     "geom:latitude":-23.867982,
     "geom:longitude":32.093796,
@@ -100,9 +100,10 @@
         "hasc:id":"MZ.GA.MG",
         "wd:id":"Q5487847"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879701,
-    "wof:geomhash":"3bae61b60ca9899b36766e281bcd7683",
+    "wof:geomhash":"c02f87eecf5f8eae8e56e57ebc8254d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091699347,
-    "wof:lastmodified":1690848243,
+    "wof:lastmodified":1695886399,
     "wof:name":"Massingir",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/169/938/3/1091699383.geojson
+++ b/data/109/169/938/3/1091699383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.483757,
-    "geom:area_square_m":5351991372.276596,
+    "geom:area_square_m":5351990317.016582,
     "geom:bbox":"32.106552,-26.866438,32.963688,-26.034319",
     "geom:latitude":-26.526892,
     "geom:longitude":32.563104,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MP.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879703,
-    "wof:geomhash":"0a2baf88582e9ed243bd30ade615f7b8",
+    "wof:geomhash":"242893ed80ded6ad54ff978b2987fc83",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091699383,
-    "wof:lastmodified":1627522451,
+    "wof:lastmodified":1695886061,
     "wof:name":"Matutuine",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/941/1/1091699411.geojson
+++ b/data/109/169/941/1/1091699411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.672945,
-    "geom:area_square_m":8077312280.164042,
+    "geom:area_square_m":8077312997.954754,
     "geom:bbox":"36.113075,-14.366103,37.745808,-13.430336",
     "geom:latitude":-13.901954,
     "geom:longitude":37.040516,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879704,
-    "wof:geomhash":"5b0c523c7cf90aa88fb5002d8b44fddf",
+    "wof:geomhash":"247184ffe4ae3a6d2d2db086e6a2aa1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091699411,
-    "wof:lastmodified":1627522451,
+    "wof:lastmodified":1695886062,
     "wof:name":"Maua",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/946/5/1091699465.geojson
+++ b/data/109/169/946/5/1091699465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.76392,
-    "geom:area_square_m":9231365255.086218,
+    "geom:area_square_m":9231366313.842623,
     "geom:bbox":"35.888672,-12.763216,36.948711,-11.567369",
     "geom:latitude":-12.234798,
     "geom:longitude":36.406514,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879706,
-    "wof:geomhash":"bddf782d3bdfb1ade5e3c20b9eaf1342",
+    "wof:geomhash":"706d5036b1d39cf3fd4b8ebf225857d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091699465,
-    "wof:lastmodified":1627522451,
+    "wof:lastmodified":1695886062,
     "wof:name":"Mavago",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/950/9/1091699509.geojson
+++ b/data/109/169/950/9/1091699509.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.IN.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879708,
     "wof:geomhash":"5a4dcbf0392d9892a0bb07c762747ca9",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091699509,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886798,
     "wof:name":"Maxixe",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/169/955/3/1091699553.geojson
+++ b/data/109/169/955/3/1091699553.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879709,
     "wof:geomhash":"f9b7fb8b2807d8f608d600b15b02c5a4",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091699553,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886063,
     "wof:name":"Mecanhelas",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/960/1/1091699601.geojson
+++ b/data/109/169/960/1/1091699601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309414,
-    "geom:area_square_m":3690658714.468999,
+    "geom:area_square_m":3690658342.992687,
     "geom:bbox":"39.194008,-15.649422,40.070221,-14.852736",
     "geom:latitude":-15.281907,
     "geom:longitude":39.646605,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.NM.MC",
         "wd:id":"Q541581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879710,
-    "wof:geomhash":"64e8c26d706639ff289b3b59d7200cdb",
+    "wof:geomhash":"f8d748b7faf5d32d37b6388d4008e6d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091699601,
-    "wof:lastmodified":1690848242,
+    "wof:lastmodified":1695886398,
     "wof:name":"Meconta",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/965/3/1091699653.geojson
+++ b/data/109/169/965/3/1091699653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.602756,
-    "geom:area_square_m":7216506731.568329,
+    "geom:area_square_m":7216507531.043633,
     "geom:bbox":"38.483738,-14.963293,39.340492,-13.935059",
     "geom:latitude":-14.476192,
     "geom:longitude":38.915932,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879712,
-    "wof:geomhash":"32ea1eb1cd4129ca2f5050ab42d5b991",
+    "wof:geomhash":"176fe97c2c349b54374b19be2a531113",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091699653,
-    "wof:lastmodified":1627522452,
+    "wof:lastmodified":1695886063,
     "wof:name":"Mecuburi",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/968/3/1091699683.geojson
+++ b/data/109/169/968/3/1091699683.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"MZ.CD.AN",
         "wd:id":"Q2640799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879714,
     "wof:geomhash":"8cf2d16e40be6b5f741b57f9afd2d93f",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091699683,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886397,
     "wof:name":"Mecufi",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/973/1/1091699731.geojson
+++ b/data/109/169/973/1/1091699731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.495283,
-    "geom:area_square_m":18087943599.151569,
+    "geom:area_square_m":18087943024.929047,
     "geom:bbox":"36.588055,-12.676298,38.487164,-11.259965",
     "geom:latitude":-11.958364,
     "geom:longitude":37.565232,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879715,
-    "wof:geomhash":"6a6927f8f6c1115988af27bf50fa29c2",
+    "wof:geomhash":"ab2b424a36cd687ecd9f9fb0e1af0d14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091699731,
-    "wof:lastmodified":1627522452,
+    "wof:lastmodified":1695886063,
     "wof:name":"Mecula",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/977/1/1091699771.geojson
+++ b/data/109/169/977/1/1091699771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.476386,
-    "geom:area_square_m":5751717544.155856,
+    "geom:area_square_m":5751717142.176787,
     "geom:bbox":"39.124989,-12.856531,40.238831,-12.06321",
     "geom:latitude":-12.465315,
     "geom:longitude":39.623914,
@@ -112,9 +112,10 @@
         "hasc:id":"MZ.CD.ML",
         "wd:id":"Q2444709"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879717,
-    "wof:geomhash":"f39620a293b8787d2f557275314bacfb",
+    "wof:geomhash":"03d1f41c5a502856463d1f8230d3da37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1091699771,
-    "wof:lastmodified":1690848240,
+    "wof:lastmodified":1695886396,
     "wof:name":"Meluco",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/169/979/9/1091699799.geojson
+++ b/data/109/169/979/9/1091699799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372228,
-    "geom:area_square_m":4466579734.836581,
+    "geom:area_square_m":4466579641.196002,
     "geom:bbox":"40.017879,-14.476028,40.740101,-13.453867",
     "geom:latitude":-13.96591,
     "geom:longitude":40.394368,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.NM.MM",
         "wd:id":"Q6436086"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879718,
-    "wof:geomhash":"a6a950801fedeeea5994878281e2f5dd",
+    "wof:geomhash":"3a9fd085cce52bc9bca2fa8aa4fcead8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091699799,
-    "wof:lastmodified":1690848240,
+    "wof:lastmodified":1695886397,
     "wof:name":"Memba",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/169/984/5/1091699845.geojson
+++ b/data/109/169/984/5/1091699845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.407127,
-    "geom:area_square_m":4877716352.683493,
+    "geom:area_square_m":4877716502.594869,
     "geom:bbox":"36.181355,-14.643411,37.594151,-14.016244",
     "geom:latitude":-14.322469,
     "geom:longitude":36.862712,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879720,
-    "wof:geomhash":"1f978c4f018651dc0cad9ee87cd03fa1",
+    "wof:geomhash":"bdd20700ec4127da4a4584be60a7ac1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091699845,
-    "wof:lastmodified":1627522452,
+    "wof:lastmodified":1695886064,
     "wof:name":"Metarica",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/169/989/5/1091699895.geojson
+++ b/data/109/169/989/5/1091699895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.829546,
-    "geom:area_square_m":9859135161.693619,
+    "geom:area_square_m":9859136770.543015,
     "geom:bbox":"35.277073,-16.651176,36.602142,-15.260135",
     "geom:latitude":-16.017008,
     "geom:longitude":35.989203,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.ZA.ML",
         "wd:id":"Q1131922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879721,
-    "wof:geomhash":"a67a02213872018ad6e81000d14ab68d",
+    "wof:geomhash":"a53fc25c903a4302975437543ab1b6e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091699895,
-    "wof:lastmodified":1690848249,
+    "wof:lastmodified":1695886406,
     "wof:name":"Milange",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/169/992/5/1091699925.geojson
+++ b/data/109/169/992/5/1091699925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.410712,
-    "geom:area_square_m":4589642908.19961,
+    "geom:area_square_m":4589643882.291473,
     "geom:bbox":"31.977472,-25.844479,32.624783,-24.785419",
     "geom:latitude":-25.345616,
     "geom:longitude":32.253863,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.MP.MO",
         "wd:id":"Q6484207"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879723,
-    "wof:geomhash":"2f5c06c69cbdac3d37abf8070c201da3",
+    "wof:geomhash":"710e90df54499ca54e2a9d5f1e3e8d83",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091699925,
-    "wof:lastmodified":1690848241,
+    "wof:lastmodified":1695886398,
     "wof:name":"Moamba",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/169/997/1/1091699971.geojson
+++ b/data/109/169/997/1/1091699971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711859,
-    "geom:area_square_m":8462338613.887712,
+    "geom:area_square_m":8462338227.145743,
     "geom:bbox":"33.365742,-16.617929,34.460361,-15.407207",
     "geom:latitude":-15.972854,
     "geom:longitude":34.003451,
@@ -139,9 +139,10 @@
         "hasc:id":"MZ.TE.MT",
         "wd:id":"Q2403251"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879725,
-    "wof:geomhash":"58d8d596d29ce8607a57ebd7443e0572",
+    "wof:geomhash":"44b34e9b075ff35314c9eedb323dfe9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1091699971,
-    "wof:lastmodified":1690848236,
+    "wof:lastmodified":1695886797,
     "wof:name":"Moatize",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/170/001/3/1091700013.geojson
+++ b/data/109/170/001/3/1091700013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287739,
-    "geom:area_square_m":3487317464.424683,
+    "geom:area_square_m":3487317406.063238,
     "geom:bbox":"39.79076,-11.753597,40.654163,-11.051172",
     "geom:latitude":-11.433989,
     "geom:longitude":40.165167,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.CD.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879726,
-    "wof:geomhash":"c64f9d0e47192e28938acdcb817c238d",
+    "wof:geomhash":"61f0faec9387dd4579ef831333ac8dfc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091700013,
-    "wof:lastmodified":1627522452,
+    "wof:lastmodified":1695886064,
     "wof:name":"Mocimboa da Praia",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/004/7/1091700047.geojson
+++ b/data/109/170/004/7/1091700047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.743845,
-    "geom:area_square_m":8802680640.699888,
+    "geom:area_square_m":8802680465.725319,
     "geom:bbox":"36.123951,-17.403265,37.533306,-16.298565",
     "geom:latitude":-16.853331,
     "geom:longitude":36.863398,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879728,
-    "wof:geomhash":"9a0e1628ce565b9a3b4f7abe7fd46b48",
+    "wof:geomhash":"b8942d0263a35ebaeb2997d8ee9525fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1091700047,
-    "wof:lastmodified":1636501812,
+    "wof:lastmodified":1695886800,
     "wof:name":"Mocuba",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/009/1/1091700091.geojson
+++ b/data/109/170/009/1/1091700091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.371043,
-    "geom:area_square_m":4420291949.113189,
+    "geom:area_square_m":4420291499.070944,
     "geom:bbox":"39.730045,-15.953723,40.57906,-15.093995",
     "geom:latitude":-15.539174,
     "geom:longitude":40.087354,
@@ -101,9 +101,10 @@
         "hasc:id":"MZ.NM.MG",
         "wd:id":"Q6436050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879730,
-    "wof:geomhash":"3078d362fc2ca3086eef70346f9ff49a",
+    "wof:geomhash":"c2f8d0eec0b4ad3c310ad5aaa247963e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091700091,
-    "wof:lastmodified":1690848254,
+    "wof:lastmodified":1695886409,
     "wof:name":"Mogincual",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/013/3/1091700133.geojson
+++ b/data/109/170/013/3/1091700133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.397248,
-    "geom:area_square_m":4727897678.036261,
+    "geom:area_square_m":4727897998.35712,
     "geom:bbox":"38.793144,-16.078844,39.820663,-15.367579",
     "geom:latitude":-15.737599,
     "geom:longitude":39.259709,
@@ -100,9 +100,10 @@
         "hasc:id":"MZ.NM.MV",
         "wd:id":"Q6890719"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879731,
-    "wof:geomhash":"bd9aa86210aa4e0dea41222c9dd1895d",
+    "wof:geomhash":"b6006150530d07271c51bbdaaf715541",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091700133,
-    "wof:lastmodified":1690848251,
+    "wof:lastmodified":1695886408,
     "wof:name":"Mogovolas",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/015/5/1091700155.geojson
+++ b/data/109/170/015/5/1091700155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.486724,
-    "geom:area_square_m":5774799355.884637,
+    "geom:area_square_m":5774799073.407854,
     "geom:bbox":"38.845428,-16.901962,39.793861,-15.888737",
     "geom:latitude":-16.357195,
     "geom:longitude":39.2703,
@@ -136,9 +136,10 @@
         "hasc:id":"MZ.NM.MO",
         "wd:id":"Q948247"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879733,
-    "wof:geomhash":"ba7081059059b5e5732280761c5cc06d",
+    "wof:geomhash":"9b32005e971b354f5d026e9b3c83384a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091700155,
-    "wof:lastmodified":1690848251,
+    "wof:lastmodified":1695886799,
     "wof:name":"Moma",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/017/7/1091700177.geojson
+++ b/data/109/170/017/7/1091700177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.295107,
-    "geom:area_square_m":3528098892.633243,
+    "geom:area_square_m":3528099499.638527,
     "geom:bbox":"39.803406,-15.225465,40.500103,-14.387663",
     "geom:latitude":-14.791901,
     "geom:longitude":40.135338,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.NM.MN",
         "wd:id":"Q2918508"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879735,
-    "wof:geomhash":"9e513cb79d2aac2f294ca118f2de4bb3",
+    "wof:geomhash":"b5dd25b751273f50f0322d398493149b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091700177,
-    "wof:lastmodified":1690848256,
+    "wof:lastmodified":1695886412,
     "wof:name":"Monapo",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/022/1/1091700221.geojson
+++ b/data/109/170/022/1/1091700221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.481371,
-    "geom:area_square_m":17875599322.564842,
+    "geom:area_square_m":17875599704.527218,
     "geom:bbox":"37.938332,-13.48283,39.412109,-11.763962",
     "geom:latitude":-12.604018,
     "geom:longitude":38.728147,
@@ -151,9 +151,10 @@
         "hasc:id":"MZ.CD.MN",
         "wd:id":"Q8604234"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879736,
-    "wof:geomhash":"a7c679ae8e620992526cb7d06aae9fa8",
+    "wof:geomhash":"1cfa8503ce54a9fa0ccdd966f322e5b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1091700221,
-    "wof:lastmodified":1690848252,
+    "wof:lastmodified":1695886799,
     "wof:name":"Montepuez",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/025/1/1091700251.geojson
+++ b/data/109/170/025/1/1091700251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.652636,
-    "geom:area_square_m":7682211458.036354,
+    "geom:area_square_m":7682211051.364604,
     "geom:bbox":"35.313103,-18.231964,36.717598,-17.500454",
     "geom:latitude":-17.832918,
     "geom:longitude":36.062597,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879738,
-    "wof:geomhash":"310365063e6802876e17796852694d9c",
+    "wof:geomhash":"9a98f62c3abb7b76b503c485850e8261",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091700251,
-    "wof:lastmodified":1627522452,
+    "wof:lastmodified":1695886065,
     "wof:name":"Mopeia",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/025/5/1091700255.geojson
+++ b/data/109/170/025/5/1091700255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.085027,
-    "geom:area_square_m":12826218760.022444,
+    "geom:area_square_m":12826218933.12541,
     "geom:bbox":"35.145626,-17.655827,36.459145,-16.352329",
     "geom:latitude":-17.057371,
     "geom:longitude":35.790253,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879740,
-    "wof:geomhash":"abdd220f0eb72556d6becf26a2ca6653",
+    "wof:geomhash":"8354631a572ca2fbb5835b3a7090296b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091700255,
-    "wof:lastmodified":1627522453,
+    "wof:lastmodified":1695886065,
     "wof:name":"Morrumbala",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/025/9/1091700259.geojson
+++ b/data/109/170/025/9/1091700259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.227919,
-    "geom:area_square_m":2585037377.973614,
+    "geom:area_square_m":2585037118.633888,
     "geom:bbox":"34.793007,-23.799559,35.434708,-23.042503",
     "geom:latitude":-23.474027,
     "geom:longitude":35.09889,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.IN.MO",
         "wd:id":"Q6318315"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879741,
-    "wof:geomhash":"21d94b2ee1bf309c2b0a18313fbd7b00",
+    "wof:geomhash":"7460225e22559b962f2caa650ceb28e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091700259,
-    "wof:lastmodified":1690848252,
+    "wof:lastmodified":1695886408,
     "wof:name":"Morrumbene",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/170/028/7/1091700287.geojson
+++ b/data/109/170/028/7/1091700287.geojson
@@ -88,6 +88,7 @@
         "hasc:id":"MZ.NM.MS",
         "wd:id":"Q6436077"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879743,
     "wof:geomhash":"a82e3e5d981363b301fcaebe8321f224",
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091700287,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886413,
     "wof:name":"Mossuril",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/033/1/1091700331.geojson
+++ b/data/109/170/033/1/1091700331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.434988,
-    "geom:area_square_m":5037608457.427942,
+    "geom:area_square_m":5037607513.900527,
     "geom:bbox":"32.486347,-20.914734,33.514111,-20.027195",
     "geom:latitude":-20.513622,
     "geom:longitude":32.943321,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879745,
-    "wof:geomhash":"e8e7a12df81303bac7db314be3e6721c",
+    "wof:geomhash":"5610639870519fab0655857d556147b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091700331,
-    "wof:lastmodified":1627522453,
+    "wof:lastmodified":1695886066,
     "wof:name":"Mossurize",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/170/037/7/1091700377.geojson
+++ b/data/109/170/037/7/1091700377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.64466,
-    "geom:area_square_m":7533204114.127779,
+    "geom:area_square_m":7533203962.586595,
     "geom:bbox":"34.473976,-19.530384,35.689133,-18.64064",
     "geom:latitude":-19.083992,
     "geom:longitude":35.058863,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879746,
-    "wof:geomhash":"50e45be9f764a3c6687c0ee5b7217f87",
+    "wof:geomhash":"f6d78507726220c98e82e34507a61f63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091700377,
-    "wof:lastmodified":1627522453,
+    "wof:lastmodified":1695886066,
     "wof:name":"Muanza",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/170/040/9/1091700409.geojson
+++ b/data/109/170/040/9/1091700409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.344574,
-    "geom:area_square_m":4121577848.846797,
+    "geom:area_square_m":4121577569.04268,
     "geom:bbox":"39.186047,-15.009346,40.004452,-14.307763",
     "geom:latitude":-14.682592,
     "geom:longitude":39.533772,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.NM.MU",
         "wd:id":"Q6436042"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879748,
-    "wof:geomhash":"e11e3126643f0e721e0fdbb4a30361c5",
+    "wof:geomhash":"d68847ce764acc5e36085da9983d70e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091700409,
-    "wof:lastmodified":1690848253,
+    "wof:lastmodified":1695886408,
     "wof:name":"Muecate",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/045/7/1091700457.geojson
+++ b/data/109/170/045/7/1091700457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.930546,
-    "geom:area_square_m":11271706273.698885,
+    "geom:area_square_m":11271707201.202387,
     "geom:bbox":"38.402538,-12.117845,39.869244,-11.010775",
     "geom:latitude":-11.589132,
     "geom:longitude":39.130263,
@@ -121,9 +121,10 @@
         "hasc:id":"MZ.CD.MD",
         "wd:id":"Q2444671"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879750,
-    "wof:geomhash":"cf546484a3d53cb943922293361bbbb3",
+    "wof:geomhash":"d5674acff84337fb7f9a2d2e22afcaea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1091700457,
-    "wof:lastmodified":1690848256,
+    "wof:lastmodified":1695886412,
     "wof:name":"Mueda",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/050/5/1091700505.geojson
+++ b/data/109/170/050/5/1091700505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.483114,
-    "geom:area_square_m":5824722458.018725,
+    "geom:area_square_m":5824722165.78111,
     "geom:bbox":"35.415188,-13.329155,36.419323,-12.224082",
     "geom:latitude":-12.824453,
     "geom:longitude":35.812471,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879751,
-    "wof:geomhash":"17c02d499558aea30fd6ccbf506e1817",
+    "wof:geomhash":"bbcecb22ee50aa3c5564ef0f9bfe4d14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091700505,
-    "wof:lastmodified":1627522453,
+    "wof:lastmodified":1695886067,
     "wof:name":"Muembe",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/170/054/3/1091700543.geojson
+++ b/data/109/170/054/3/1091700543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173868,
-    "geom:area_square_m":2104220568.100488,
+    "geom:area_square_m":2104220744.667048,
     "geom:bbox":"39.53614,-12.083484,40.26318,-11.621447",
     "geom:latitude":-11.833785,
     "geom:longitude":39.836886,
@@ -112,9 +112,10 @@
         "hasc:id":"MZ.CD.MB",
         "wd:id":"Q2444727"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879753,
-    "wof:geomhash":"f67e6cefb036d3c747ed4306f64909f4",
+    "wof:geomhash":"750599aa0451054cbabb1cbc29dd8ae2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1091700543,
-    "wof:lastmodified":1690848253,
+    "wof:lastmodified":1695886410,
     "wof:name":"Muidumbe",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/058/9/1091700589.geojson
+++ b/data/109/170/058/9/1091700589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26043,
-    "geom:area_square_m":3104623491.269587,
+    "geom:area_square_m":3104623360.427864,
     "geom:bbox":"38.258518,-15.785432,39.010071,-15.049574",
     "geom:latitude":-15.400686,
     "geom:longitude":38.661173,
@@ -106,9 +106,10 @@
         "hasc:id":"MZ.NM.MR",
         "wd:id":"Q6436054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879754,
-    "wof:geomhash":"cf3b79973da447399bf244c5f3a7ba7c",
+    "wof:geomhash":"efb82f67646484a3c05591e45cee2b79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091700589,
-    "wof:lastmodified":1690848257,
+    "wof:lastmodified":1695886413,
     "wof:name":"Murrupula",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/063/7/1091700637.geojson
+++ b/data/109/170/063/7/1091700637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.539881,
-    "geom:area_square_m":6388410808.197715,
+    "geom:area_square_m":6388410808.198453,
     "geom:bbox":"34.0695381165,-17.7011394501,35.3460731506,-16.2574195862",
     "geom:latitude":-16.867345,
     "geom:longitude":34.772666,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879756,
-    "wof:geomhash":"7529cd429e891f18bc97cc6d395d2f7c",
+    "wof:geomhash":"0952f8e99653231f683300d598665266",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091700637,
-    "wof:lastmodified":1566646675,
+    "wof:lastmodified":1695886410,
     "wof:name":"Mutarara",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/170/068/5/1091700685.geojson
+++ b/data/109/170/068/5/1091700685.geojson
@@ -127,6 +127,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.NV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879757,
     "wof:geomhash":"2f432c026cb766f7370eb9f862b67eaa",
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1091700685,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886801,
     "wof:name":"Nacala",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/072/7/1091700727.geojson
+++ b/data/109/170/072/7/1091700727.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.NV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879759,
     "wof:geomhash":"4e78b1918e4ec4e67150eb5eb7c0ff0a",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091700727,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886068,
     "wof:name":"Nacala-A-Velha",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/077/3/1091700773.geojson
+++ b/data/109/170/077/3/1091700773.geojson
@@ -116,7 +116,7 @@
         }
     ],
     "wof:id":1091700773,
-    "wof:lastmodified":1694492406,
+    "wof:lastmodified":1695886408,
     "wof:name":"Nacaroa",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/077/3/1091700773.geojson
+++ b/data/109/170/077/3/1091700773.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"MZ.NM.NR",
         "wd:id":"Q6436058"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879761,
     "wof:geomhash":"df2aeedde9e29fcd7b5259f6741e05c6",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091700773,
-    "wof:lastmodified":1695886408,
+    "wof:lastmodified":1696023152,
     "wof:name":"Nacaroa",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/082/5/1091700825.geojson
+++ b/data/109/170/082/5/1091700825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194086,
-    "geom:area_square_m":2155899996.49015,
+    "geom:area_square_m":2155900598.479616,
     "geom:bbox":"31.931303,-26.471977,32.402122,-25.674046",
     "geom:latitude":-26.060371,
     "geom:longitude":32.161518,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.MP.NA",
         "wd:id":"Q6484217"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879762,
-    "wof:geomhash":"c91d1bb2cc3d093365b1e3003fb40bd3",
+    "wof:geomhash":"182c0197c692f56a6ac952818ecae2db",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091700825,
-    "wof:lastmodified":1690848252,
+    "wof:lastmodified":1695886409,
     "wof:name":"Namaacha",
     "wof:parent_id":85674849,
     "wof:placetype":"county",

--- a/data/109/170/086/5/1091700865.geojson
+++ b/data/109/170/086/5/1091700865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.171904,
-    "geom:area_square_m":2027446382.121537,
+    "geom:area_square_m":2027446617.525617,
     "geom:bbox":"36.789238,-17.760813,37.365421,-17.182865",
     "geom:latitude":-17.481231,
     "geom:longitude":37.072915,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879764,
-    "wof:geomhash":"e8a96a7c5466ee14d9523f6b0a61627f",
+    "wof:geomhash":"f2e9cdf559f4ee63a133b363ca936e09",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091700865,
-    "wof:lastmodified":1627522454,
+    "wof:lastmodified":1695886068,
     "wof:name":"Namacurra",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/091/5/1091700915.geojson
+++ b/data/109/170/091/5/1091700915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25825,
-    "geom:area_square_m":3071811439.646617,
+    "geom:area_square_m":3071811248.244635,
     "geom:bbox":"36.48122,-16.253559,37.128578,-15.483329",
     "geom:latitude":-15.855276,
     "geom:longitude":36.807057,
@@ -111,9 +111,10 @@
         "hasc:id":"MZ.ZA.NR",
         "wd:id":"Q1131334"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879766,
-    "wof:geomhash":"8c765961e613782b0f5f2904bb72d03e",
+    "wof:geomhash":"ff4c4393f17d7b6ead70fa282baba888",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091700915,
-    "wof:lastmodified":1690848253,
+    "wof:lastmodified":1695886409,
     "wof:name":"Namarroi",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/096/5/1091700965.geojson
+++ b/data/109/170/096/5/1091700965.geojson
@@ -193,7 +193,7 @@
         }
     ],
     "wof:id":1091700965,
-    "wof:lastmodified":1694492940,
+    "wof:lastmodified":1695886800,
     "wof:name":"Nampula",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/096/5/1091700965.geojson
+++ b/data/109/170/096/5/1091700965.geojson
@@ -181,6 +181,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.RN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879767,
     "wof:geomhash":"4587b0579063fb4b5aaa77b9ed2b63c1",
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":1091700965,
-    "wof:lastmodified":1695886800,
+    "wof:lastmodified":1696023154,
     "wof:name":"Nampula",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/099/5/1091700995.geojson
+++ b/data/109/170/099/5/1091700995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.499853,
-    "geom:area_square_m":6003783615.806667,
+    "geom:area_square_m":6003782616.129254,
     "geom:bbox":"38.4324,-14.164414,39.380157,-13.3082",
     "geom:latitude":-13.743559,
     "geom:longitude":38.894539,
@@ -112,9 +112,10 @@
         "hasc:id":"MZ.CD.NM",
         "wd:id":"Q2444738"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879769,
-    "wof:geomhash":"236b4f7c7cae769c50ccee71f151bdad",
+    "wof:geomhash":"9caa854c948c758a51c913d46f8db730",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1091700995,
-    "wof:lastmodified":1690848254,
+    "wof:lastmodified":1695886410,
     "wof:name":"Namuno",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/104/3/1091701043.geojson
+++ b/data/109/170/104/3/1091701043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.245555,
-    "geom:area_square_m":2978910661.816834,
+    "geom:area_square_m":2978909733.980537,
     "geom:bbox":"39.501274,-11.482928,40.081169,-10.811793",
     "geom:latitude":-11.160008,
     "geom:longitude":39.775698,
@@ -112,9 +112,10 @@
         "hasc:id":"MZ.CD.NG",
         "wd:id":"Q2444699"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879770,
-    "wof:geomhash":"add6908df7e87709ede882bd738f796b",
+    "wof:geomhash":"8673b747c65cc3eb5f0592f4fc738662",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1091701043,
-    "wof:lastmodified":1690848250,
+    "wof:lastmodified":1695886407,
     "wof:name":"Nangade",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/109/1/1091701091.geojson
+++ b/data/109/170/109/1/1091701091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25123,
-    "geom:area_square_m":3016549590.479442,
+    "geom:area_square_m":3016548961.432015,
     "geom:bbox":"35.162159,-14.109421,36.069576,-13.553683",
     "geom:latitude":-13.821497,
     "geom:longitude":35.573689,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879772,
-    "wof:geomhash":"45d4ee7a8814f47adc31542c554aabe6",
+    "wof:geomhash":"b8fbae8a30c8b5fa568ed5a685ebbf2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091701091,
-    "wof:lastmodified":1627522453,
+    "wof:lastmodified":1695886067,
     "wof:name":"Ngauma",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/170/111/9/1091701119.geojson
+++ b/data/109/170/111/9/1091701119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.34516,
-    "geom:area_square_m":4027263287.849708,
+    "geom:area_square_m":4027262999.784407,
     "geom:bbox":"33.935829,-19.66305,34.568611,-18.945494",
     "geom:latitude":-19.333932,
     "geom:longitude":34.240487,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.SO.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879773,
-    "wof:geomhash":"f86527840bbc23dbb72b27e300b5ef44",
+    "wof:geomhash":"c1853042c8c6e5bd6f65cb950b128805",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091701119,
-    "wof:lastmodified":1627522454,
+    "wof:lastmodified":1695886068,
     "wof:name":"Nhamatanda",
     "wof:parent_id":85674835,
     "wof:placetype":"county",

--- a/data/109/170/116/3/1091701163.geojson
+++ b/data/109/170/116/3/1091701163.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879775,
     "wof:geomhash":"3300a5880e92d7e7924bff0a5a4b710b",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091701163,
-    "wof:lastmodified":1694498061,
+    "wof:lastmodified":1695886070,
     "wof:name":"Nicoadala",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/118/9/1091701189.geojson
+++ b/data/109/170/118/9/1091701189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.418331,
-    "geom:area_square_m":5019346179.478348,
+    "geom:area_square_m":5019345485.228434,
     "geom:bbox":"37.433807,-14.318092,38.402946,-13.492641",
     "geom:latitude":-13.987139,
     "geom:longitude":37.903566,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NS.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879776,
-    "wof:geomhash":"fb836476b82491d0a1ef10f88e93d552",
+    "wof:geomhash":"fb059e476fe82b1c7fb3a344cac27512",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091701189,
-    "wof:lastmodified":1627522455,
+    "wof:lastmodified":1695886070,
     "wof:name":"Nipepe",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/170/122/3/1091701223.geojson
+++ b/data/109/170/122/3/1091701223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291269,
-    "geom:area_square_m":3537015791.157493,
+    "geom:area_square_m":3537015457.23201,
     "geom:bbox":"39.968952,-11.245667,40.717762,-10.472198",
     "geom:latitude":-10.865417,
     "geom:longitude":40.32058,
@@ -106,9 +106,10 @@
         "hasc:id":"MZ.CD.PA",
         "wd:id":"Q2444715"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879778,
-    "wof:geomhash":"ade7dc02da4aaac2d9b97a3bd8ca5a39",
+    "wof:geomhash":"1c4ec9bdccceafd7b3407d0745ae5176",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091701223,
-    "wof:lastmodified":1690848257,
+    "wof:lastmodified":1695886414,
     "wof:name":"Palma",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/126/5/1091701265.geojson
+++ b/data/109/170/126/5/1091701265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.607309,
-    "geom:area_square_m":6859459602.837438,
+    "geom:area_square_m":6859459914.305963,
     "geom:bbox":"33.891216,-24.537121,35.002422,-23.575882",
     "geom:latitude":-24.014515,
     "geom:longitude":34.401541,
@@ -142,9 +142,10 @@
         "hasc:id":"MZ.IN.PA",
         "wd:id":"Q6318344"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879780,
-    "wof:geomhash":"e7ea664253a790b9bce5f66e262b663e",
+    "wof:geomhash":"46d9c5332e2175eed35d623d02ad0630",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1091701265,
-    "wof:lastmodified":1690848255,
+    "wof:lastmodified":1695886800,
     "wof:name":"Panda",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/170/129/1/1091701291.geojson
+++ b/data/109/170/129/1/1091701291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.855998,
-    "geom:area_square_m":10137035304.653671,
+    "geom:area_square_m":10137035504.317316,
     "geom:bbox":"37.898399,-17.298,39.138893,-16.117882",
     "geom:latitude":-16.719077,
     "geom:longitude":38.540059,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.ZA.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879781,
-    "wof:geomhash":"2d781f170961aafa8b52ec9b70d5284c",
+    "wof:geomhash":"d72610f35c5269b3eace2c904f20c471",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091701291,
-    "wof:lastmodified":1627522455,
+    "wof:lastmodified":1695886071,
     "wof:name":"Pebane",
     "wof:parent_id":85674839,
     "wof:placetype":"county",

--- a/data/109/170/132/5/1091701325.geojson
+++ b/data/109/170/132/5/1091701325.geojson
@@ -117,6 +117,7 @@
     "wof:concordances":{
         "hasc:id":"MZ.CD.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879783,
     "wof:geomhash":"a8aa49a28e67cb7d6ac65da54f72a22e",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1091701325,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886799,
     "wof:name":"Pemba",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/137/1/1091701371.geojson
+++ b/data/109/170/137/1/1091701371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176183,
-    "geom:area_square_m":2126291624.288934,
+    "geom:area_square_m":2126291812.054035,
     "geom:bbox":"40.004177,-12.843288,40.626106,-12.305911",
     "geom:latitude":-12.572696,
     "geom:longitude":40.322755,
@@ -109,9 +109,10 @@
         "hasc:id":"MZ.CD.QU",
         "wd:id":"Q2444690"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879785,
-    "wof:geomhash":"36a4f993aaf4ebf8c11ceff503e7ac23",
+    "wof:geomhash":"2165d4557e085a494f3024a07bb2e9b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091701371,
-    "wof:lastmodified":1690848256,
+    "wof:lastmodified":1695886412,
     "wof:name":"Quissanga",
     "wof:parent_id":85674817,
     "wof:placetype":"county",

--- a/data/109/170/141/5/1091701415.geojson
+++ b/data/109/170/141/5/1091701415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525095,
-    "geom:area_square_m":6271422112.08996,
+    "geom:area_square_m":6271422226.114036,
     "geom:bbox":"37.596626,-15.45443,38.815468,-14.576456",
     "geom:latitude":-15.006763,
     "geom:longitude":38.195855,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.NM.RI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879786,
-    "wof:geomhash":"7d69d37d712b501c7c4b99571cc2bf98",
+    "wof:geomhash":"f32a8da82db4b71836ffd6cab00c6dc1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091701415,
-    "wof:lastmodified":1627522455,
+    "wof:lastmodified":1695886072,
     "wof:name":"Ribaue",
     "wof:parent_id":85674827,
     "wof:placetype":"county",

--- a/data/109/170/144/3/1091701443.geojson
+++ b/data/109/170/144/3/1091701443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.038012,
-    "geom:area_square_m":12546071546.784212,
+    "geom:area_square_m":12546071878.597582,
     "geom:bbox":"34.96492,-13.164228,36.289318,-11.409412",
     "geom:latitude":-12.17645,
     "geom:longitude":35.560348,
@@ -97,9 +97,10 @@
         "hasc:id":"MZ.NS.SA",
         "wd:id":"Q7417763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879788,
-    "wof:geomhash":"f14fc3730aad1271b594ed9aaa7bec3d",
+    "wof:geomhash":"8fa5c2c85639f664e399d72e8eda4fab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091701443,
-    "wof:lastmodified":1690848254,
+    "wof:lastmodified":1695886411,
     "wof:name":"Sanga",
     "wof:parent_id":85674821,
     "wof:placetype":"county",

--- a/data/109/170/148/3/1091701483.geojson
+++ b/data/109/170/148/3/1091701483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.612744,
-    "geom:area_square_m":7134477293.536384,
+    "geom:area_square_m":7134477348.650207,
     "geom:bbox":"32.776741,-20.243958,33.850288,-19.109716",
     "geom:latitude":-19.670789,
     "geom:longitude":33.264745,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879790,
-    "wof:geomhash":"d4f3472b913525e740fb6708da6144fd",
+    "wof:geomhash":"c6642f9caf9fb7c1b273bc266b90e736",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091701483,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886073,
     "wof:name":"Sussundenga",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/170/152/9/1091701529.geojson
+++ b/data/109/170/152/9/1091701529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.363514,
-    "geom:area_square_m":4299321992.703291,
+    "geom:area_square_m":4299323066.759008,
     "geom:bbox":"33.810352,-17.385168,34.541496,-16.572437",
     "geom:latitude":-16.963363,
     "geom:longitude":34.105076,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.MN.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879791,
-    "wof:geomhash":"39a189a989996a87854fac982550e72f",
+    "wof:geomhash":"0319cd370b6116833cc65fd2d51f8f2b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091701529,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886073,
     "wof:name":"Tambara",
     "wof:parent_id":85674815,
     "wof:placetype":"county",

--- a/data/109/170/156/1/1091701561.geojson
+++ b/data/109/170/156/1/1091701561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307921,
-    "geom:area_square_m":3675570758.452037,
+    "geom:area_square_m":3675570799.067426,
     "geom:bbox":"33.99136,-15.492231,34.623917,-14.682219",
     "geom:latitude":-15.125688,
     "geom:longitude":34.344551,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MZ.TE.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879793,
-    "wof:geomhash":"c56390b74bd462860847324780d50bfd",
+    "wof:geomhash":"4ad18891ec1a09c117e7916368b0854e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091701561,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886074,
     "wof:name":"Tsangano",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/109/170/160/5/1091701605.geojson
+++ b/data/109/170/160/5/1091701605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.513023,
-    "geom:area_square_m":5869030526.036427,
+    "geom:area_square_m":5869030137.270134,
     "geom:bbox":"34.510494,-22.796541,35.547588,-21.799208",
     "geom:latitude":-22.300894,
     "geom:longitude":35.126772,
@@ -101,9 +101,10 @@
         "hasc:id":"MZ.IN.VI",
         "wd:id":"Q6316575"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879795,
-    "wof:geomhash":"68c07266fbfae25997c20ffbb7447a5e",
+    "wof:geomhash":"e33385c85d55ecfaa5aa7f3236a3da04",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091701605,
-    "wof:lastmodified":1690848250,
+    "wof:lastmodified":1695886407,
     "wof:name":"Vilankulo",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/170/165/1/1091701651.geojson
+++ b/data/109/170/165/1/1091701651.geojson
@@ -89,6 +89,7 @@
         "hasc:id":"MZ.GA.XX",
         "wd:id":"Q2215180"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879796,
     "wof:geomhash":"54cdf17f024f5cf609b2fca4f87ecfe7",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091701651,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886412,
     "wof:name":"Xai-xai",
     "wof:parent_id":85674831,
     "wof:placetype":"county",

--- a/data/109/170/168/1/1091701681.geojson
+++ b/data/109/170/168/1/1091701681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.179355,
-    "geom:area_square_m":2015656111.720083,
+    "geom:area_square_m":2015655391.49628,
     "geom:bbox":"34.297821,-24.861891,35.106506,-24.460108",
     "geom:latitude":-24.650625,
     "geom:longitude":34.668897,
@@ -103,9 +103,10 @@
         "hasc:id":"MZ.IN.ZA",
         "wd:id":"Q6318329"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879798,
-    "wof:geomhash":"4c60db8e1a520f23ec3a79dd174da78a",
+    "wof:geomhash":"28f668cd9603f48b9ec841e1a73cfa1a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091701681,
-    "wof:lastmodified":1690848250,
+    "wof:lastmodified":1695886407,
     "wof:name":"Zavala",
     "wof:parent_id":85674845,
     "wof:placetype":"county",

--- a/data/109/170/172/9/1091701729.geojson
+++ b/data/109/170/172/9/1091701729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.009108,
-    "geom:area_square_m":12039406874.624044,
+    "geom:area_square_m":12039405879.318974,
     "geom:bbox":"30.212154,-15.725474,31.628174,-14.642006",
     "geom:latitude":-15.231061,
     "geom:longitude":30.933203,
@@ -98,9 +98,10 @@
         "hasc:id":"MZ.TE.ZU",
         "wd:id":"Q3741737"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MZ",
     "wof:created":1473879799,
-    "wof:geomhash":"f40f5a4275fe8a011abc88b9ae495d4c",
+    "wof:geomhash":"c8df1782571f299d9f1cbc68518e80b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091701729,
-    "wof:lastmodified":1690848255,
+    "wof:lastmodified":1695886411,
     "wof:name":"Zumbu",
     "wof:parent_id":85674811,
     "wof:placetype":"county",

--- a/data/856/327/29/85632729.geojson
+++ b/data/856/327/29/85632729.geojson
@@ -1150,6 +1150,7 @@
         "hasc:id":"MZ",
         "icao:code":"C9",
         "ioc:id":"MOZ",
+        "iso:code":"MZ",
         "itu:id":"MOZ",
         "loc:id":"n81082759",
         "m49:code":"508",
@@ -1164,6 +1165,7 @@
         "wk:page":"Mozambique",
         "wmo:id":"MZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:country_alpha3":"MOZ",
     "wof:geom_alt":[
@@ -1185,7 +1187,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1694639543,
+    "wof:lastmodified":1695881201,
     "wof:name":"Mozambique",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/748/11/85674811.geojson
+++ b/data/856/748/11/85674811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.483088,
-    "geom:area_square_m":101064031748.031494,
+    "geom:area_square_m":101064032389.326294,
     "geom:bbox":"30.212154,-17.701139,35.346073,-13.998883",
     "geom:latitude":-15.517025,
     "geom:longitude":32.768905,
@@ -304,17 +304,19 @@
         "gn:id":1026010,
         "gp:id":2346318,
         "hasc:id":"MZ.TE",
+        "iso:code":"MZ-T",
         "iso:id":"MZ-T",
         "qs_pg:id":423835,
         "unlc:id":"MZ-T",
         "wd:id":"Q605787",
         "wk:page":"Tete Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"effb2019694aa07e94dbd5ac8ccdd1b5",
+    "wof:geomhash":"1bbe33dbfda9d593c3e655b70c2c6ae5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848221,
+    "wof:lastmodified":1695884908,
     "wof:name":"Tete",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/15/85674815.geojson
+++ b/data/856/748/15/85674815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.349249,
-    "geom:area_square_m":62510843104.45153,
+    "geom:area_square_m":62510842271.250656,
     "geom:bbox":"32.363888,-21.582447,34.541496,-16.387352",
     "geom:latitude":-19.023514,
     "geom:longitude":33.430399,
@@ -301,17 +301,19 @@
         "gn:id":1040947,
         "gp:id":2346320,
         "hasc:id":"MZ.MN",
+        "iso:code":"MZ-B",
         "iso:id":"MZ-B",
         "qs_pg:id":891330,
         "unlc:id":"MZ-B",
         "wd:id":"Q622792",
         "wk:page":"Manica Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0768b23e9cb44f14bbdf22f19d803173",
+    "wof:geomhash":"f2fec71dcbeb7033ba3d56f5c25d483d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848226,
+    "wof:lastmodified":1695884911,
     "wof:name":"Manica",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/17/85674817.geojson
+++ b/data/856/748/17/85674817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.47797,
-    "geom:area_square_m":78205964504.16864,
+    "geom:area_square_m":78205963273.771927,
     "geom:bbox":"37.938332,-14.164414,40.717762,-10.472198",
     "geom:latitude":-12.460629,
     "geom:longitude":39.365495,
@@ -311,17 +311,19 @@
         "gn:id":1051823,
         "gp:id":2346311,
         "hasc:id":"MZ.CD",
+        "iso:code":"MZ-P",
         "iso:id":"MZ-P",
         "qs_pg:id":388548,
         "unlc:id":"MZ-P",
         "wd:id":"Q466538",
         "wk:page":"Cabo Delgado Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0da98b71f8fd09b4ec36f1130cc2883",
+    "wof:geomhash":"adf814c26c559383da802d803bb2de45",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848223,
+    "wof:lastmodified":1695884909,
     "wof:name":"Cabo Delgado",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/21/85674821.geojson
+++ b/data/856/748/21/85674821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.786688,
-    "geom:area_square_m":129912224519.950073,
+    "geom:area_square_m":129912223950.175598,
     "geom:bbox":"34.350483,-15.479039,38.487164,-11.259965",
     "geom:latitude":-13.058082,
     "geom:longitude":36.461944,
@@ -307,16 +307,18 @@
         "gn:id":1030006,
         "gp:id":2346317,
         "hasc:id":"MZ.NS",
+        "iso:code":"MZ-A",
         "iso:id":"MZ-A",
         "qs_pg:id":894927,
         "wd:id":"Q622799",
         "wk:page":"Niassa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53ddc16665b5fd654066fee65a36b9c2",
+    "wof:geomhash":"d83e846378c6ba60563bb959747faaef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848224,
+    "wof:lastmodified":1695884909,
     "wof:name":"Niassa",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/27/85674827.geojson
+++ b/data/856/748/27/85674827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.568638,
-    "geom:area_square_m":78461268063.995544,
+    "geom:area_square_m":78461267514.7034,
     "geom:bbox":"36.695835,-16.901962,40.840626,-13.445104",
     "geom:latitude":-14.966443,
     "geom:longitude":39.24871,
@@ -300,17 +300,19 @@
         "gn:id":1033354,
         "gp:id":2346316,
         "hasc:id":"MZ.NM",
+        "iso:code":"MZ-N",
         "iso:id":"MZ-N",
         "qs_pg:id":894926,
         "unlc:id":"MZ-N",
         "wd:id":"Q622794",
         "wk:page":"Nampula Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42576d6403f89300e5690d2a5c81a3af",
+    "wof:geomhash":"5f3530bbaeda74da54e0bddbbe77ea43",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848220,
+    "wof:lastmodified":1695884907,
     "wof:name":"Nampula",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/31/85674831.geojson
+++ b/data/856/748/31/85674831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.656118,
-    "geom:area_square_m":75569101872.324188,
+    "geom:area_square_m":75569101923.072479,
     "geom:bbox":"31.306313,-25.380955,34.473415,-21.309015",
     "geom:latitude":-23.321273,
     "geom:longitude":32.804189,
@@ -314,17 +314,19 @@
         "gn:id":1046058,
         "gp:id":2346312,
         "hasc:id":"MZ.GA",
+        "iso:code":"MZ-G",
         "iso:id":"MZ-G",
         "qs_pg:id":1091217,
         "unlc:id":"MZ-G",
         "wd:id":"Q466526",
         "wk:page":"Gaza Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f559f127393bc82e593a4ad56e3c72d8",
+    "wof:geomhash":"05ef9c726992f623a9a45dbe9f69bcdd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848224,
+    "wof:lastmodified":1695884910,
     "wof:name":"Gaza",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/35/85674835.geojson
+++ b/data/856/748/35/85674835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.816035,
-    "geom:area_square_m":67961061174.603462,
+    "geom:area_square_m":67961062152.470825,
     "geom:bbox":"33.384979,-21.316055,36.189751,-16.797598",
     "geom:latitude":-19.062121,
     "geom:longitude":34.671009,
@@ -305,17 +305,19 @@
         "gn:id":1026804,
         "gp:id":2346315,
         "hasc:id":"MZ.SO",
+        "iso:code":"MZ-S",
         "iso:id":"MZ-S",
         "qs_pg:id":1091220,
         "unlc:id":"MZ-S",
         "wd:id":"Q622801",
         "wk:page":"Sofala Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3eb773f3366f5600b9c8b80852b3b31",
+    "wof:geomhash":"cff091cf9c220e29b5c514f302d7332c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848219,
+    "wof:lastmodified":1695884906,
     "wof:name":"Sofala",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/39/85674839.geojson
+++ b/data/856/748/39/85674839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.731604,
-    "geom:area_square_m":103427907346.697159,
+    "geom:area_square_m":103427908664.75798,
     "geom:bbox":"35.145626,-18.90237,39.138893,-14.999998",
     "geom:latitude":-16.655114,
     "geom:longitude":36.982826,
@@ -305,16 +305,18 @@
         "gn:id":1024312,
         "gp:id":2346319,
         "hasc:id":"MZ.ZA",
+        "iso:code":"MZ-Q",
         "iso:id":"MZ-Q",
         "qs_pg:id":423836,
         "wd:id":"Q622803",
         "wk:page":"Zambezia Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6e94aedee01a24681a68650d5848dd82",
+    "wof:geomhash":"b44621435f555febcd96003adf72bab2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848225,
+    "wof:lastmodified":1695884911,
     "wof:name":"Zambezia",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/45/85674845.geojson
+++ b/data/856/748/45/85674845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.05076,
-    "geom:area_square_m":68958465586.081558,
+    "geom:area_square_m":68958466824.664642,
     "geom:bbox":"33.161545,-24.861891,35.604565,-20.954969",
     "geom:latitude":-22.809418,
     "geom:longitude":34.51514,
@@ -308,17 +308,19 @@
         "gn:id":1045110,
         "gp:id":2346313,
         "hasc:id":"MZ.IN",
+        "iso:code":"MZ-I",
         "iso:id":"MZ-I",
         "qs_pg:id":1091218,
         "unlc:id":"MZ-I",
         "wd:id":"Q466547",
         "wk:page":"Inhambane Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac9d0fe7643faf14b5b2761e0526e303",
+    "wof:geomhash":"41f0859d95d5cc8b7064a7b373c3807d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848222,
+    "wof:lastmodified":1695884908,
     "wof:name":"Inhambane",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/49/85674849.geojson
+++ b/data/856/748/49/85674849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.090452,
-    "geom:area_square_m":23322829966.318237,
+    "geom:area_square_m":23322828686.808334,
     "geom:bbox":"31.931303,-26.866438,33.137318,-24.203913",
     "geom:latitude":-25.531224,
     "geom:longitude":32.450893,
@@ -249,16 +249,18 @@
         "gn:id":1040649,
         "gp:id":2346314,
         "hasc:id":"MZ.MP",
+        "iso:code":"MZ-L",
         "iso:id":"MZ-L",
         "qs_pg:id":1091219,
         "wd:id":"Q379658",
         "wk:page":"Maputo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"39cd55734c722b2dfe9852aff62fafa5",
+    "wof:geomhash":"3d1ff9fd5e6a3aa3a88b1821447489dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -273,7 +275,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848227,
+    "wof:lastmodified":1695884912,
     "wof:name":"Maputo",
     "wof:parent_id":85632729,
     "wof:placetype":"region",

--- a/data/856/748/53/85674853.geojson
+++ b/data/856/748/53/85674853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031277,
-    "geom:area_square_m":347722440.470392,
+    "geom:area_square_m":347722803.424633,
     "geom:bbox":"32.440636,-26.094553,32.995689,-25.810024",
     "geom:latitude":-25.96106,
     "geom:longitude":32.624996,
@@ -256,11 +256,13 @@
         "gn:id":1040649,
         "gp:id":2346314,
         "hasc:id":"MZ.MC",
+        "iso:code":"MZ-MPM",
         "iso:id":"MZ-MPM",
         "qs_pg:id":1091219,
         "wd:id":"Q379658",
         "wk:page":"Maputo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421167893
     ],
@@ -268,7 +270,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9585e0ec50caff62c4420436bb809530",
+    "wof:geomhash":"7509d7334570a180ff26f579d1a0b109",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690848225,
+    "wof:lastmodified":1695884911,
     "wof:name":"Maputo",
     "wof:parent_id":85632729,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.